### PR TITLE
feat: Stage 0 diagnosis + minimal MDX route for Unidad Electricidad

### DIFF
--- a/docs/mdx-migration-plan.md
+++ b/docs/mdx-migration-plan.md
@@ -1,0 +1,80 @@
+# Plan de migración JSON → MDX (Unidad Electricidad)
+
+## Objetivo
+Migrar de forma incremental el contenido de `Unidad Electricidad` desde archivos JSON hacia MDX real, **sin romper** la ruta actual en producción (`/unidad/electricidad/[slug]`) y manteniendo compatibilidad con build/deploy en Vercel.
+
+## ETAPA 0 — Diagnóstico del estado actual
+
+### 1) ¿Dónde vive el contenido actual y quién lo consume?
+
+#### Fuente de contenido (JSON)
+- Carpeta de contenido principal: `src/content/electricidad/*.json`
+- Loader de contenido JSON: `src/lib/content.ts`
+  - `getAllTopicSlugs()` lista slugs desde archivos `.json`.
+  - `getTopicContentBySlug(slug)` lee y parsea cada JSON.
+
+#### Páginas/componentes consumidores
+- Ruta principal por tema: `src/app/unidad/electricidad/[slug]/page.tsx`
+  - Genera `static params` con slugs JSON.
+  - Renderiza bloques (`topic.blocks`) y secciones (`topic.sections`) con IDs para hash navigation.
+- Índice de unidad: `src/app/unidad/electricidad/page.tsx`
+  - Usa la estructura de navegación para links de entrada a Parte 1/2.
+- Layout con sidebar: `src/app/unidad/electricidad/layout.tsx`
+  - Monta el `Sidebar` para toda la unidad.
+
+#### Dependencias indirectas importantes
+- `scripts/generate-search-index.mjs`
+  - Lee `src/content/nav.ts` + JSON para construir `src/content/search-index.json`.
+  - Actualmente depende de que exista JSON para cada slug de `/unidad/electricidad/...`.
+
+---
+
+### 2) ¿Cómo se construye sidebar/nav y cómo funciona hash navigation?
+
+#### Sidebar/nav
+- Árbol base hardcodeado: `src/content/nav.ts` (`electricidadNav`).
+  - Define páginas (`isPage: true`) y subtemas internos/anchors (`isPage: false`, `href` con `#hash`).
+- Helpers de navegación: `src/lib/nav.ts`
+  - `getSectionNodes()`: secciones para sidebar.
+  - `getTopicNodes()`: páginas navegables (sin anchors) para prev/next.
+  - `getPrevNextBySlug()`: navegación secuencial.
+- Render del sidebar: `src/components/layout/Sidebar.tsx`
+  - Compara `pathname` con `href` sin hash para estado activo.
+  - Los subitems con hash navegan a anchors dentro de la página.
+
+#### Hash navigation de subtemas
+- En JSON, cada sección interna se renderiza como:
+  - `<section id={section.id} className="scroll-mt-24 ...">` en `src/app/unidad/electricidad/[slug]/page.tsx`.
+- El hash funciona porque:
+  1. `nav.ts` apunta a `/unidad/electricidad/<slug>#<id>`.
+  2. La página tiene elementos con `id=<id>`.
+  3. `scroll-mt-24` evita que el header fijo tape el título.
+
+---
+
+### 3) Decisión técnica recomendada
+
+Para priorizar estabilidad y DX en PRs pequeños:
+
+1. **Mantener intacta la ruta JSON actual** durante la migración.
+2. **Agregar una ruta temporal MDX paralela** (`/unidad/electricidad-mdx/[slug]`) para validar pipeline.
+3. **Crear utilidades MDX dedicadas** (`src/lib/mdx.ts`) para lectura por `unit + slug`.
+4. **No mutar todavía `src/content/nav.ts` ni search** en esta etapa.
+5. En etapa posterior, unificar datos con un adaptador (JSON/MDX) y recién ahí mover navegación, prev/next, anchors y search al nuevo backend de contenido.
+
+Esta estrategia reduce blast radius: si falla MDX, la experiencia de `/unidad/electricidad/*` sigue operativa.
+
+## ETAPA 1 — MDX mínimo (alcance de este PR)
+
+- Soporte de lectura MDX por slug en `src/lib/mdx.ts`.
+- Ruta temporal `app/unidad/electricidad-mdx/[slug]/page.tsx`.
+- Archivo demo: `src/content/electricidad/metodos-electrificacion.mdx`.
+- Enlace/compatibilidad: no se reemplaza ni rompe la ruta JSON existente.
+
+## Próximos pasos sugeridos (ETAPA 2)
+
+1. Crear árbol de navegación para MDX (o extender `nav.ts` con base única).
+2. Agregar prev/next para ruta MDX usando orden/frontmatter.
+3. Resolver anchors automáticos desde headings MDX y validar deep-links (`#...`).
+4. Adaptar generación de search-index para coexistencia JSON+MDX.
+5. Plan de switch controlado de `/unidad/electricidad/[slug]` a backend MDX cuando exista cobertura completa.

--- a/package.json
+++ b/package.json
@@ -12,10 +12,16 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
+    "gray-matter": "^4.0.3",
+    "katex": "^0.16.11",
     "next": "16.1.6",
+    "next-mdx-remote": "^5.0.0",
     "next-themes": "^0.4.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "rehype-katex": "^7.0.1",
+    "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/src/app/unidad/electricidad-mdx/[slug]/page.tsx
+++ b/src/app/unidad/electricidad-mdx/[slug]/page.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from "react";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { createPageMetadata } from "@/lib/seo";
+import { getAllMdxSlugs, getMdxBySlug } from "@/lib/mdx";
+
+type PageProps = {
+  params: Promise<{ slug: string }>;
+};
+
+async function renderMdx(source: string): Promise<ReactNode> {
+  try {
+    const runtimeImport = new Function("moduleName", "return import(moduleName)") as (moduleName: string) => Promise<unknown>;
+    const [{ compileMDX }, remarkGfmModule, remarkMathModule, rehypeKatexModule] = await Promise.all([
+      runtimeImport("next-mdx-remote/rsc") as Promise<{ compileMDX: (input: { source: string; options: { parseFrontmatter: boolean; mdxOptions: { remarkPlugins: unknown[]; rehypePlugins: unknown[] } } }) => Promise<{ content: ReactNode }> }>,
+      runtimeImport("remark-gfm") as Promise<{ default: unknown }>,
+      runtimeImport("remark-math") as Promise<{ default: unknown }>,
+      runtimeImport("rehype-katex") as Promise<{ default: unknown }>,
+    ]);
+
+    const compiled = await compileMDX({
+      source,
+      options: {
+        parseFrontmatter: false,
+        mdxOptions: {
+          remarkPlugins: [remarkGfmModule.default, remarkMathModule.default],
+          rehypePlugins: [rehypeKatexModule.default],
+        },
+      },
+    });
+
+    return compiled.content;
+  } catch {
+    return <pre className="overflow-x-auto whitespace-pre-wrap rounded-xl border border-slate-200 p-4 text-sm dark:border-slate-800">{source}</pre>;
+  }
+}
+
+export async function generateStaticParams() {
+  const slugs = await getAllMdxSlugs("electricidad");
+  return slugs.map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const topic = await getMdxBySlug("electricidad", slug);
+
+  if (!topic) {
+    return createPageMetadata({ title: "Tema no encontrado", description: "No se encontró el tema solicitado.", path: `/unidad/electricidad-mdx/${slug}` });
+  }
+
+  return createPageMetadata({
+    title: topic.frontmatter.title,
+    description: topic.frontmatter.description,
+    path: `/unidad/electricidad-mdx/${slug}`,
+  });
+}
+
+export default async function ElectricidadMdxTopicPage({ params }: PageProps) {
+  const { slug } = await params;
+  const topic = await getMdxBySlug("electricidad", slug);
+
+  if (!topic) notFound();
+
+  const content = await renderMdx(topic.source);
+
+  return (
+    <article className="mx-auto w-full max-w-3xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
+      <header className="space-y-2 border-b border-slate-200 pb-6 dark:border-slate-800">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Parte {topic.frontmatter.part}</p>
+        <h1 className="text-3xl font-bold tracking-tight">{topic.frontmatter.title}</h1>
+        <p className="text-slate-600 dark:text-slate-300">{topic.frontmatter.description}</p>
+      </header>
+      <section className="prose prose-slate max-w-none dark:prose-invert [&_h2]:scroll-mt-24 [&_h3]:scroll-mt-24">{content}</section>
+    </article>
+  );
+}

--- a/src/content/electricidad/metodos-electrificacion.mdx
+++ b/src/content/electricidad/metodos-electrificacion.mdx
@@ -1,0 +1,30 @@
+---
+title: "Métodos de electrificación de un cuerpo"
+description: "Plantilla MDX temporal para migración controlada."
+part: 1
+order: 1
+---
+
+## Idea clave
+
+PENDIENTE: pegar texto base del chat.
+
+## Mini explicación
+
+PENDIENTE: pegar texto base del chat.
+
+## Ejemplo numérico (SI)
+
+PENDIENTE: pegar ejemplo numérico con unidades SI.
+
+### Por frotamiento {#por-frotamiento}
+
+PENDIENTE: pegar texto base del chat.
+
+### Por contacto {#por-contacto}
+
+PENDIENTE: pegar texto base del chat.
+
+### Por inducción {#por-induccion}
+
+PENDIENTE: pegar texto base del chat.

--- a/src/lib/mdx.ts
+++ b/src/lib/mdx.ts
@@ -1,0 +1,105 @@
+import path from "node:path";
+import { cache } from "react";
+
+type UnitName = "electricidad";
+
+type MdxFrontmatter = {
+  title: string;
+  description: string;
+  part: 1 | 2;
+  order: number;
+};
+
+type MdxRecord = {
+  frontmatter: MdxFrontmatter;
+  source: string;
+};
+
+const CONTENT_ROOT = path.join(process.cwd(), "src", "content");
+
+function getUnitPath(unit: UnitName) {
+  return path.join(CONTENT_ROOT, unit);
+}
+
+function parseFrontmatterFallback(raw: string): MdxRecord {
+  if (!raw.startsWith("---")) {
+    return {
+      frontmatter: {
+        title: "Sin título",
+        description: "",
+        part: 1,
+        order: 0,
+      },
+      source: raw,
+    };
+  }
+
+  const [, fmChunk = "", ...contentParts] = raw.split("---");
+  const source = contentParts.join("---").trimStart();
+
+  const values = Object.fromEntries(
+    fmChunk
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const [key, ...rest] = line.split(":");
+        return [key.trim(), rest.join(":").trim().replace(/^"|"$/g, "")];
+      }),
+  );
+
+  return {
+    frontmatter: {
+      title: values.title ?? "Sin título",
+      description: values.description ?? "",
+      part: Number(values.part) === 2 ? 2 : 1,
+      order: Number(values.order ?? 0),
+    },
+    source,
+  };
+}
+
+async function parseMdxSource(raw: string): Promise<MdxRecord> {
+  try {
+    const runtimeImport = new Function("moduleName", "return import(moduleName)") as (moduleName: string) => Promise<unknown>;
+    const matterModule = (await runtimeImport("gray-matter")) as {
+      default: (input: string) => { data: Partial<MdxFrontmatter>; content: string };
+    };
+
+    const parsed = matterModule.default(raw);
+
+    return {
+      frontmatter: {
+        title: parsed.data.title ?? "Sin título",
+        description: parsed.data.description ?? "",
+        part: parsed.data.part === 2 ? 2 : 1,
+        order: Number(parsed.data.order ?? 0),
+      },
+      source: parsed.content,
+    };
+  } catch {
+    return parseFrontmatterFallback(raw);
+  }
+}
+
+export const getAllMdxSlugs = cache(async (unit: UnitName) => {
+  const fs = await import("node:fs/promises");
+  const files = await fs.readdir(getUnitPath(unit));
+
+  return files
+    .filter((file) => file.endsWith(".mdx"))
+    .map((file) => file.replace(/\.mdx$/, ""))
+    .sort();
+});
+
+export const getMdxBySlug = cache(async (unit: UnitName, slug: string): Promise<MdxRecord | null> => {
+  const fs = await import("node:fs/promises");
+  const filePath = path.join(getUnitPath(unit), `${slug}.mdx`);
+
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    return parseMdxSource(raw);
+  } catch {
+    return null;
+  }
+});


### PR DESCRIPTION
### Motivation
- Preparar una migración incremental de la unidad `Electricidad` desde JSON a MDX sin romper la ruta actual basada en JSON y priorizando estabilidad y buena DX.
- Proveer una ruta paralela y utilidades mínimas MDX para validar el pipeline y la experiencia de despliegue antes de migrar el resto del contenido.

### Description
- Añade documentación de diagnóstico y plan en `docs/mdx-migration-plan.md` con mapa de archivos, consumidores, detalles de sidebar/hash y la recomendación técnica para la migración incremental.  
- Implementa utilidades MDX en `src/lib/mdx.ts` con `getMdxBySlug(unit, slug)` y `getAllMdxSlugs(unit)`; incluye parseo de frontmatter y un fallback robusto cuando no hay `gray-matter` disponible.  
- Crea una ruta temporal en App Router `src/app/unidad/electricidad-mdx/[slug]/page.tsx` que genera static params, metadata y renderiza MDX usando `next-mdx-remote` (RSC) con `remark-gfm`, `remark-math` y `rehype-katex` cargados por import dinámico y con un fallback que muestra el source en un `pre`.  
- Agrega un MDX demo placeholder en `src/content/electricidad/metodos-electrificacion.mdx` con frontmatter y las secciones/anchors solicitadas (sin contenido inventado).  
- Declara las dependencias MDX relevantes en `package.json` (`gray-matter`, `next-mdx-remote`, `remark-gfm`, `remark-math`, `rehype-katex`, `katex`) para la siguiente etapa de integración.

### Testing
- Ejecutado `npm run lint` y la tarea completó con éxito.  
- Ejecutado `npm run build` (incluye `prebuild` que genera el índice de búsqueda) y la compilación/SSG finalizó correctamente sin errores de TypeScript.  
- Inicio de servidor y verificación HTTP de la ruta temporal `GET /unidad/electricidad-mdx/metodos-electrificacion` devolvió `200 OK`.  
- Captura visual vía Playwright de la página MDX demo generada correctamente (artifact producido).  

Próximos pasos sugeridos en el siguiente PR: integrar navegación (`nav` / `prev-next`) para MDX, asegurar anchors automáticos desde headings MDX y adaptar el indexado de búsqueda para coexistir JSON+MDX.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fd0a0b208832d934dd881f6bba40c)