### PR TITLE
Stage 2: migrate Electricidad content to MDX (with JSON fallback)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,20 @@ Web de consulta tipo wiki/apunte para la unidad de Electricidad, construida con 
    - `description`
 2. Agregar el nodo correspondiente en `src/content/nav.ts` con `title`, `slug`, `part`, `order`, `description`, `href` y `children` si aplica.
 3. Si el tema tiene subitems internos, agregar headings con id en el mismo MDX (ejemplo: `<h3 id="por-frotamiento">Por frotamiento</h3>`) y enlazarlos desde `nav.ts` con `#anchor`.
+
+
+## MDX source of truth
+- La fuente principal de contenido para la Unidad Electricidad es `src/content/electricidad/*.mdx`.
+- La ruta final `/unidad/electricidad/[slug]` prioriza MDX cuando existe y hace fallback automático al JSON legado (`*.json`) si falta el MDX.
+- El índice de búsqueda (`src/content/search-index.json`) se genera desde MDX cuando está disponible y conserva fallback JSON.
+
+### Cómo agregar un tema nuevo
+1. Crear `src/content/electricidad/<slug>.mdx` con frontmatter mínimo: `title`, `description`, `part`, `order`.
+2. Mantener secciones base:
+   - `## Idea clave`
+   - `## Mini explicación`
+   - `## Ejemplo numérico (SI)`
+   - `## Fórmulas` (solo si corresponde)
+3. Si tiene subtemas, agregar `### <Título> {#anchor}` y usar el mismo `#anchor` en `src/content/nav.ts`.
+4. Agregar/ajustar el nodo del tema en `src/content/nav.ts` para sidebar, orden y prev/next.
+5. Regenerar índice: `npm run build` (ejecuta `prebuild`) o `npm run predev`.

--- a/scripts/generate-search-index.mjs
+++ b/scripts/generate-search-index.mjs
@@ -10,19 +10,20 @@ const navRaw = await fs.readFile(navPath, "utf8");
 const hrefMatches = [...navRaw.matchAll(/href:\s*"([^"]+)"/g)].map((m) => m[1]);
 const uniqueHrefs = [...new Set(hrefMatches)].filter((href) => href.startsWith("/unidad/electricidad/"));
 
-const cache = new Map();
+function parseFrontmatter(raw) {
+  const match = raw.match(/^---\n([\s\S]*?)\n---\n?/);
+  if (!match) return { frontmatter: {}, content: raw };
 
-async function readTopic(slug) {
-  if (cache.has(slug)) return cache.get(slug);
-  const filePath = path.join(contentDir, `${slug}.json`);
-  try {
-    const raw = await fs.readFile(filePath, "utf8");
-    const parsed = JSON.parse(raw);
-    cache.set(slug, parsed);
-    return parsed;
-  } catch {
-    return null;
+  const frontmatter = {};
+  for (const line of match[1].split("\n")) {
+    const idx = line.indexOf(":");
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim().replace(/^['"]|['"]$/g, "");
+    frontmatter[key] = value;
   }
+
+  return { frontmatter, content: raw.slice(match[0].length) };
 }
 
 function collectText(topic) {
@@ -41,27 +42,82 @@ function collectText(topic) {
   return chunk.join(" ");
 }
 
+function parseMdxContent(content) {
+  const body = [];
+  const sections = [];
+  let currentSection = null;
+
+  for (const line of content.split("\n")) {
+    const subHeading = line.match(/^###\s+(.+?)\s+\{#([\w-]+)\}\s*$/);
+    if (subHeading) {
+      currentSection = { id: subHeading[2], title: subHeading[1], text: [] };
+      sections.push(currentSection);
+      continue;
+    }
+
+    if (/^##\s+/.test(line)) continue;
+
+    const plain = line.replace(/^\-\s+/, "").trim();
+    if (!plain) continue;
+
+    body.push(plain);
+    if (currentSection) currentSection.text.push(plain);
+  }
+
+  return { bodyPlain: body.join(" "), sections };
+}
+
+async function readTopic(slug) {
+  const mdxPath = path.join(contentDir, `${slug}.mdx`);
+  try {
+    const raw = await fs.readFile(mdxPath, "utf8");
+    const { frontmatter, content } = parseFrontmatter(raw);
+    const { bodyPlain, sections } = parseMdxContent(content);
+    return {
+      title: frontmatter.title ?? slug,
+      description: frontmatter.description ?? slug,
+      bodyPlain,
+      sections,
+    };
+  } catch {}
+
+  const jsonPath = path.join(contentDir, `${slug}.json`);
+  try {
+    const raw = await fs.readFile(jsonPath, "utf8");
+    const parsed = JSON.parse(raw);
+    return {
+      title: parsed.title,
+      description: parsed.description,
+      bodyPlain: collectText(parsed),
+      sections: (parsed.sections ?? []).map((s) => ({ id: s.id, title: s.title, text: (s.blocks ?? []).map((b) => b.body ?? "") })),
+    };
+  } catch {
+    return null;
+  }
+}
+
 const entries = [];
 for (const href of uniqueHrefs) {
   const slug = href.split("#")[0].split("/").pop();
   if (!slug) continue;
   const topic = await readTopic(slug);
   if (!topic) continue;
+
   const hash = href.includes("#") ? href.split("#")[1] : null;
   let title = topic.title;
   let description = topic.description;
-  let bodyPlain = collectText(topic);
+  let bodyPlain = topic.bodyPlain;
 
-  if (hash && topic.sections) {
+  if (hash) {
     const section = topic.sections.find((item) => item.id === hash);
     if (section) {
       title = section.title;
       description = `${section.title} · ${topic.title}`;
-      bodyPlain = `${collectText(topic)} ${section.blocks.map((b) => b.body ?? "").join(" ")}`;
+      bodyPlain = `${topic.bodyPlain} ${section.text.join(" ")}`;
     }
   }
 
-  entries.push({ title, href, description, bodyPlain });
+  entries.push({ title, href, description, bodyPlain: bodyPlain.trim() });
 }
 
 await fs.writeFile(outputPath, `${JSON.stringify(entries, null, 2)}\n`, "utf8");

--- a/src/app/unidad/electricidad-mdx/[slug]/page.tsx
+++ b/src/app/unidad/electricidad-mdx/[slug]/page.tsx
@@ -1,88 +1,10 @@
-import type { Metadata } from "next";
-import { notFound } from "next/navigation";
-
-import { createPageMetadata } from "@/lib/seo";
-import { getAllMdxSlugs, getMdxBySlug } from "@/lib/mdx";
+import { redirect } from "next/navigation";
 
 type PageProps = {
   params: Promise<{ slug: string }>;
 };
 
-function extractHeadingId(text: string) {
-  const match = text.match(/^(.*)\s+\{#([\w-]+)\}$/);
-
-  if (!match) {
-    return { label: text, id: undefined };
-  }
-
-  return { label: match[1], id: match[2] };
-}
-
-function renderMdxLike(content: string) {
-  const lines = content.split("\n");
-
-  return lines.map((line, index) => {
-    const trimmed = line.trim();
-
-    if (!trimmed) return <div key={`spacer-${index}`} className="h-2" />;
-
-    if (trimmed.startsWith("### ")) {
-      const { label, id } = extractHeadingId(trimmed.replace(/^###\s+/, ""));
-      return (
-        <h3 key={`h3-${index}`} id={id} className="scroll-mt-24 text-lg font-semibold text-slate-900 dark:text-slate-100">
-          {label}
-        </h3>
-      );
-    }
-
-    if (trimmed.startsWith("## ")) {
-      const { label, id } = extractHeadingId(trimmed.replace(/^##\s+/, ""));
-      return (
-        <h2 key={`h2-${index}`} id={id} className="scroll-mt-24 mt-4 text-2xl font-semibold tracking-tight">
-          {label}
-        </h2>
-      );
-    }
-
-    return (
-      <p key={`p-${index}`} className="text-slate-700 dark:text-slate-300">
-        {trimmed}
-      </p>
-    );
-  });
-}
-
-export async function generateStaticParams() {
-  const slugs = await getAllMdxSlugs("electricidad");
-  return slugs.map((slug) => ({ slug }));
-}
-
-export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+export default async function ElectricidadMdxRedirectPage({ params }: PageProps) {
   const { slug } = await params;
-  const topic = await getMdxBySlug("electricidad", slug);
-
-  if (!topic) {
-    return createPageMetadata({ title: "Tema MDX no encontrado", description: "No se encontró el tema MDX solicitado.", path: `/unidad/electricidad-mdx/${slug}` });
-  }
-
-  return createPageMetadata({ title: topic.frontmatter.title, description: topic.frontmatter.description, path: `/unidad/electricidad-mdx/${slug}` });
-}
-
-export default async function ElectricidadMdxPage({ params }: PageProps) {
-  const { slug } = await params;
-  const topic = await getMdxBySlug("electricidad", slug);
-
-  if (!topic) notFound();
-
-  return (
-    <article className="mx-auto w-full max-w-4xl space-y-3 px-4 py-8 sm:px-6 lg:px-8">
-      <header className="space-y-2 border-b border-slate-200 pb-6 dark:border-slate-800">
-        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Parte {topic.frontmatter.part}</p>
-        <h1 className="text-3xl font-bold tracking-tight">{topic.frontmatter.title}</h1>
-        <p className="text-slate-600 dark:text-slate-300">{topic.frontmatter.description}</p>
-      </header>
-
-      <section className="space-y-2">{renderMdxLike(topic.content)}</section>
-    </article>
-  );
+  redirect(`/unidad/electricidad/${slug}`);
 }

--- a/src/content/electricidad/campo-electrico.mdx
+++ b/src/content/electricidad/campo-electrico.mdx
@@ -1,0 +1,22 @@
+---
+title: "Campo eléctrico"
+description: "Representación espacial de la acción eléctrica."
+part: 1
+order: 4
+---
+
+## Idea clave
+
+PENDIENTE: pegar texto base del chat
+
+## Mini explicación
+
+PENDIENTE: pegar texto base del chat
+
+## Ejemplo numérico (SI)
+
+PENDIENTE: pegar ejemplo numérico con unidades SI
+
+## Fórmulas
+
+- PENDIENTE: pegar fórmulas cuando aplique

--- a/src/content/electricidad/circuitos-electricos.mdx
+++ b/src/content/electricidad/circuitos-electricos.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Métodos de electrificación de un cuerpo"
-description: "Formas de electrizar un cuerpo por interacción."
-part: 1
-order: 1
+title: "Circuitos eléctricos"
+description: "Configuraciones de conexión en circuitos."
+part: 2
+order: 6
 ---
 
 ## Idea clave
@@ -17,19 +17,23 @@ PENDIENTE: pegar texto base del chat
 
 PENDIENTE: pegar ejemplo numérico con unidades SI
 
-### Por frotamiento {#por-frotamiento}
+## Fórmulas
+
+- PENDIENTE: pegar fórmulas cuando aplique
+
+### Circuitos en serie {#circuitos-en-serie}
 
 PENDIENTE: pegar texto base del chat
 
 PENDIENTE: pegar ejemplo numérico con unidades SI
 
-### Por contacto {#por-contacto}
+### Circuitos en paralelo {#circuitos-en-paralelo}
 
 PENDIENTE: pegar texto base del chat
 
 PENDIENTE: pegar ejemplo numérico con unidades SI
 
-### Por inducción {#por-induccion}
+### Circuitos mixtos {#circuitos-mixtos}
 
 PENDIENTE: pegar texto base del chat
 

--- a/src/content/electricidad/corriente-electrica.mdx
+++ b/src/content/electricidad/corriente-electrica.mdx
@@ -1,0 +1,22 @@
+---
+title: "Corriente eléctrica"
+description: "Flujo de carga eléctrica en un conductor."
+part: 2
+order: 1
+---
+
+## Idea clave
+
+PENDIENTE: pegar texto base del chat
+
+## Mini explicación
+
+PENDIENTE: pegar texto base del chat
+
+## Ejemplo numérico (SI)
+
+PENDIENTE: pegar ejemplo numérico con unidades SI
+
+## Fórmulas
+
+- PENDIENTE: pegar fórmulas cuando aplique

--- a/src/content/electricidad/energia-electrica.mdx
+++ b/src/content/electricidad/energia-electrica.mdx
@@ -1,0 +1,22 @@
+---
+title: "Energía eléctrica"
+description: "Energía consumida o entregada en circuitos."
+part: 2
+order: 9
+---
+
+## Idea clave
+
+PENDIENTE: pegar texto base del chat
+
+## Mini explicación
+
+PENDIENTE: pegar texto base del chat
+
+## Ejemplo numérico (SI)
+
+PENDIENTE: pegar ejemplo numérico con unidades SI
+
+## Fórmulas
+
+- PENDIENTE: pegar fórmulas cuando aplique

--- a/src/content/electricidad/energia-potencial-electrica.mdx
+++ b/src/content/electricidad/energia-potencial-electrica.mdx
@@ -1,0 +1,22 @@
+---
+title: "Energía potencial eléctrica"
+description: "Energía asociada a la posición en un campo eléctrico."
+part: 1
+order: 5
+---
+
+## Idea clave
+
+PENDIENTE: pegar texto base del chat
+
+## Mini explicación
+
+PENDIENTE: pegar texto base del chat
+
+## Ejemplo numérico (SI)
+
+PENDIENTE: pegar ejemplo numérico con unidades SI
+
+## Fórmulas
+
+- PENDIENTE: pegar fórmulas cuando aplique

--- a/src/content/electricidad/fuerza-electrica.mdx
+++ b/src/content/electricidad/fuerza-electrica.mdx
@@ -1,0 +1,22 @@
+---
+title: "Fuerza eléctrica"
+description: "Interacción eléctrica entre cuerpos cargados."
+part: 1
+order: 3
+---
+
+## Idea clave
+
+PENDIENTE: pegar texto base del chat
+
+## Mini explicación
+
+PENDIENTE: pegar texto base del chat
+
+## Ejemplo numérico (SI)
+
+PENDIENTE: pegar ejemplo numérico con unidades SI
+
+## Fórmulas
+
+- PENDIENTE: pegar fórmulas cuando aplique

--- a/src/content/electricidad/ley-de-coulomb.mdx
+++ b/src/content/electricidad/ley-de-coulomb.mdx
@@ -1,0 +1,22 @@
+---
+title: "Ley de Coulomb"
+description: "Relación entre cargas y fuerza eléctrica."
+part: 1
+order: 2
+---
+
+## Idea clave
+
+PENDIENTE: pegar texto base del chat
+
+## Mini explicación
+
+PENDIENTE: pegar texto base del chat
+
+## Ejemplo numérico (SI)
+
+PENDIENTE: pegar ejemplo numérico con unidades SI
+
+## Fórmulas
+
+- PENDIENTE: pegar fórmulas cuando aplique

--- a/src/content/electricidad/ley-de-joule.mdx
+++ b/src/content/electricidad/ley-de-joule.mdx
@@ -1,0 +1,22 @@
+---
+title: "Ley de Joule"
+description: "Efecto térmico asociado al paso de corriente."
+part: 2
+order: 10
+---
+
+## Idea clave
+
+PENDIENTE: pegar texto base del chat
+
+## Mini explicación
+
+PENDIENTE: pegar texto base del chat
+
+## Ejemplo numérico (SI)
+
+PENDIENTE: pegar ejemplo numérico con unidades SI
+
+## Fórmulas
+
+- PENDIENTE: pegar fórmulas cuando aplique

--- a/src/content/electricidad/ley-de-ohm.mdx
+++ b/src/content/electricidad/ley-de-ohm.mdx
@@ -1,0 +1,22 @@
+---
+title: "Ley de Ohm"
+description: "Relación entre tensión, corriente y resistencia."
+part: 2
+order: 5
+---
+
+## Idea clave
+
+PENDIENTE: pegar texto base del chat
+
+## Mini explicación
+
+PENDIENTE: pegar texto base del chat
+
+## Ejemplo numérico (SI)
+
+PENDIENTE: pegar ejemplo numérico con unidades SI
+
+## Fórmulas
+
+- PENDIENTE: pegar fórmulas cuando aplique

--- a/src/content/electricidad/leyes-de-kirchhoff.mdx
+++ b/src/content/electricidad/leyes-de-kirchhoff.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Métodos de electrificación de un cuerpo"
-description: "Formas de electrizar un cuerpo por interacción."
-part: 1
-order: 1
+title: "Leyes de Kirchhoff"
+description: "Leyes de conservación aplicadas a circuitos."
+part: 2
+order: 7
 ---
 
 ## Idea clave
@@ -17,19 +17,17 @@ PENDIENTE: pegar texto base del chat
 
 PENDIENTE: pegar ejemplo numérico con unidades SI
 
-### Por frotamiento {#por-frotamiento}
+## Fórmulas
+
+- PENDIENTE: pegar fórmulas cuando aplique
+
+### Primera ley (corrientes o nodos) — KCL {#primera-ley-corrientes-o-nodos}
 
 PENDIENTE: pegar texto base del chat
 
 PENDIENTE: pegar ejemplo numérico con unidades SI
 
-### Por contacto {#por-contacto}
-
-PENDIENTE: pegar texto base del chat
-
-PENDIENTE: pegar ejemplo numérico con unidades SI
-
-### Por inducción {#por-induccion}
+### Segunda ley (tensiones o mallas) — KVL {#segunda-ley-tensiones-o-mallas}
 
 PENDIENTE: pegar texto base del chat
 

--- a/src/content/electricidad/potencia-electrica.mdx
+++ b/src/content/electricidad/potencia-electrica.mdx
@@ -1,0 +1,22 @@
+---
+title: "Potencia eléctrica"
+description: "Ritmo de transferencia de energía eléctrica."
+part: 2
+order: 8
+---
+
+## Idea clave
+
+PENDIENTE: pegar texto base del chat
+
+## Mini explicación
+
+PENDIENTE: pegar texto base del chat
+
+## Ejemplo numérico (SI)
+
+PENDIENTE: pegar ejemplo numérico con unidades SI
+
+## Fórmulas
+
+- PENDIENTE: pegar fórmulas cuando aplique

--- a/src/content/electricidad/potencial-electrico.mdx
+++ b/src/content/electricidad/potencial-electrico.mdx
@@ -1,0 +1,22 @@
+---
+title: "Potencial eléctrico"
+description: "Trabajo por unidad de carga entre dos puntos."
+part: 1
+order: 6
+---
+
+## Idea clave
+
+PENDIENTE: pegar texto base del chat
+
+## Mini explicación
+
+PENDIENTE: pegar texto base del chat
+
+## Ejemplo numérico (SI)
+
+PENDIENTE: pegar ejemplo numérico con unidades SI
+
+## Fórmulas
+
+- PENDIENTE: pegar fórmulas cuando aplique

--- a/src/content/electricidad/resistencia-electrica.mdx
+++ b/src/content/electricidad/resistencia-electrica.mdx
@@ -1,0 +1,22 @@
+---
+title: "Resistencia eléctrica"
+description: "Oposición al paso de la corriente."
+part: 2
+order: 3
+---
+
+## Idea clave
+
+PENDIENTE: pegar texto base del chat
+
+## Mini explicación
+
+PENDIENTE: pegar texto base del chat
+
+## Ejemplo numérico (SI)
+
+PENDIENTE: pegar ejemplo numérico con unidades SI
+
+## Fórmulas
+
+- PENDIENTE: pegar fórmulas cuando aplique

--- a/src/content/electricidad/tension-electrica.mdx
+++ b/src/content/electricidad/tension-electrica.mdx
@@ -1,0 +1,22 @@
+---
+title: "Tensión eléctrica (diferencia de potencial)"
+description: "Diferencia de energía por unidad de carga."
+part: 2
+order: 2
+---
+
+## Idea clave
+
+PENDIENTE: pegar texto base del chat
+
+## Mini explicación
+
+PENDIENTE: pegar texto base del chat
+
+## Ejemplo numérico (SI)
+
+PENDIENTE: pegar ejemplo numérico con unidades SI
+
+## Fórmulas
+
+- PENDIENTE: pegar fórmulas cuando aplique

--- a/src/content/electricidad/variacion-de-la-resistencia.mdx
+++ b/src/content/electricidad/variacion-de-la-resistencia.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Métodos de electrificación de un cuerpo"
-description: "Formas de electrizar un cuerpo por interacción."
-part: 1
-order: 1
+title: "Variación de la resistencia"
+description: "Factores geométricos y físicos de la resistencia."
+part: 2
+order: 4
 ---
 
 ## Idea clave
@@ -17,19 +17,29 @@ PENDIENTE: pegar texto base del chat
 
 PENDIENTE: pegar ejemplo numérico con unidades SI
 
-### Por frotamiento {#por-frotamiento}
+## Fórmulas
+
+- PENDIENTE: pegar fórmulas cuando aplique
+
+### Con la longitud {#con-la-longitud}
 
 PENDIENTE: pegar texto base del chat
 
 PENDIENTE: pegar ejemplo numérico con unidades SI
 
-### Por contacto {#por-contacto}
+### Con el área de la sección {#con-el-area-de-la-seccion}
 
 PENDIENTE: pegar texto base del chat
 
 PENDIENTE: pegar ejemplo numérico con unidades SI
 
-### Por inducción {#por-induccion}
+### Con el material {#con-el-material}
+
+PENDIENTE: pegar texto base del chat
+
+PENDIENTE: pegar ejemplo numérico con unidades SI
+
+### Con la temperatura {#con-la-temperatura}
 
 PENDIENTE: pegar texto base del chat
 

--- a/src/content/search-index.json
+++ b/src/content/search-index.json
@@ -3,25 +3,25 @@
     "title": "Métodos de electrificación de un cuerpo",
     "href": "/unidad/electricidad/metodos-electrificacion",
     "description": "Formas de electrizar un cuerpo por interacción.",
-    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Por frotamiento PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Por contacto PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Por inducción PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
+    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
   },
   {
     "title": "Por frotamiento",
     "href": "/unidad/electricidad/metodos-electrificacion#por-frotamiento",
     "description": "Por frotamiento · Métodos de electrificación de un cuerpo",
-    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Por frotamiento PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Por contacto PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Por inducción PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
+    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
   },
   {
     "title": "Por contacto",
     "href": "/unidad/electricidad/metodos-electrificacion#por-contacto",
     "description": "Por contacto · Métodos de electrificación de un cuerpo",
-    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Por frotamiento PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Por contacto PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Por inducción PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
+    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
   },
   {
     "title": "Por inducción",
     "href": "/unidad/electricidad/metodos-electrificacion#por-induccion",
     "description": "Por inducción · Métodos de electrificación de un cuerpo",
-    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Por frotamiento PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Por contacto PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Por inducción PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
+    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
   },
   {
     "title": "Ley de Coulomb",
@@ -75,31 +75,31 @@
     "title": "Variación de la resistencia",
     "href": "/unidad/electricidad/variacion-de-la-resistencia",
     "description": "Factores geométricos y físicos de la resistencia.",
-    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique Con la longitud PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Con el área de la sección PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Con el material PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Con la temperatura PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
+    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
   },
   {
     "title": "Con la longitud",
     "href": "/unidad/electricidad/variacion-de-la-resistencia#con-la-longitud",
     "description": "Con la longitud · Variación de la resistencia",
-    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique Con la longitud PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Con el área de la sección PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Con el material PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Con la temperatura PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
+    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
   },
   {
     "title": "Con el área de la sección",
     "href": "/unidad/electricidad/variacion-de-la-resistencia#con-el-area-de-la-seccion",
     "description": "Con el área de la sección · Variación de la resistencia",
-    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique Con la longitud PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Con el área de la sección PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Con el material PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Con la temperatura PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
+    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
   },
   {
     "title": "Con el material",
     "href": "/unidad/electricidad/variacion-de-la-resistencia#con-el-material",
     "description": "Con el material · Variación de la resistencia",
-    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique Con la longitud PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Con el área de la sección PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Con el material PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Con la temperatura PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
+    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
   },
   {
     "title": "Con la temperatura",
     "href": "/unidad/electricidad/variacion-de-la-resistencia#con-la-temperatura",
     "description": "Con la temperatura · Variación de la resistencia",
-    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique Con la longitud PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Con el área de la sección PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Con el material PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Con la temperatura PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
+    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
   },
   {
     "title": "Ley de Ohm",
@@ -111,43 +111,43 @@
     "title": "Circuitos eléctricos",
     "href": "/unidad/electricidad/circuitos-electricos",
     "description": "Configuraciones de conexión en circuitos.",
-    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique Circuitos en serie PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Circuitos en paralelo PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Circuitos mixtos PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
+    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
   },
   {
     "title": "Circuitos en serie",
     "href": "/unidad/electricidad/circuitos-electricos#circuitos-en-serie",
     "description": "Circuitos en serie · Circuitos eléctricos",
-    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique Circuitos en serie PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Circuitos en paralelo PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Circuitos mixtos PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
+    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
   },
   {
     "title": "Circuitos en paralelo",
     "href": "/unidad/electricidad/circuitos-electricos#circuitos-en-paralelo",
     "description": "Circuitos en paralelo · Circuitos eléctricos",
-    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique Circuitos en serie PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Circuitos en paralelo PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Circuitos mixtos PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
+    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
   },
   {
     "title": "Circuitos mixtos",
     "href": "/unidad/electricidad/circuitos-electricos#circuitos-mixtos",
     "description": "Circuitos mixtos · Circuitos eléctricos",
-    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique Circuitos en serie PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Circuitos en paralelo PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Circuitos mixtos PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
+    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
   },
   {
     "title": "Leyes de Kirchhoff",
     "href": "/unidad/electricidad/leyes-de-kirchhoff",
     "description": "Leyes de conservación aplicadas a circuitos.",
-    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique Primera ley (corrientes o nodos) PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Segunda ley (tensiones o mallas) PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
+    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
   },
   {
-    "title": "Primera ley (corrientes o nodos)",
+    "title": "Primera ley (corrientes o nodos) — KCL",
     "href": "/unidad/electricidad/leyes-de-kirchhoff#primera-ley-corrientes-o-nodos",
-    "description": "Primera ley (corrientes o nodos) · Leyes de Kirchhoff",
-    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique Primera ley (corrientes o nodos) PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Segunda ley (tensiones o mallas) PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
+    "description": "Primera ley (corrientes o nodos) — KCL · Leyes de Kirchhoff",
+    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
   },
   {
-    "title": "Segunda ley (tensiones o mallas)",
+    "title": "Segunda ley (tensiones o mallas) — KVL",
     "href": "/unidad/electricidad/leyes-de-kirchhoff#segunda-ley-tensiones-o-mallas",
-    "description": "Segunda ley (tensiones o mallas) · Leyes de Kirchhoff",
-    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique Primera ley (corrientes o nodos) PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI Segunda ley (tensiones o mallas) PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
+    "description": "Segunda ley (tensiones o mallas) — KVL · Leyes de Kirchhoff",
+    "bodyPlain": "PENDIENTE: pegar texto base del chat PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar fórmulas cuando aplique PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI PENDIENTE: pegar texto base del chat PENDIENTE: pegar ejemplo numérico con unidades SI"
   },
   {
     "title": "Potencia eléctrica",

--- a/src/lib/content.ts
+++ b/src/lib/content.ts
@@ -1,22 +1,30 @@
 import path from "node:path";
 import { cache } from "react";
 
+import { getMdxBySlug } from "@/lib/mdx";
 import type { TopicContent } from "@/types";
 
 const CONTENT_ROOT = path.join(process.cwd(), "src", "content", "electricidad");
 
-async function readTopicFiles() {
+export const getAllTopicSlugs = cache(async () => {
   const fs = await import("node:fs/promises");
   const files = await fs.readdir(CONTENT_ROOT);
-  return files.filter((file) => file.endsWith(".json") && !file.startsWith("search-index"));
-}
-
-export const getAllTopicSlugs = cache(async () => {
-  const files = await readTopicFiles();
-  return files.map((file) => file.replace(/\.json$/, "")).sort();
+  return [...new Set(files.filter((file) => /\.(json|mdx)$/.test(file)).map((file) => file.replace(/\.(json|mdx)$/, "")))].sort();
 });
 
 export const getTopicContentBySlug = cache(async (slug: string): Promise<TopicContent | null> => {
+  const mdxTopic = await getMdxBySlug("electricidad", slug);
+
+  if (mdxTopic) {
+    return {
+      title: mdxTopic.frontmatter.title,
+      description: mdxTopic.frontmatter.description,
+      part: mdxTopic.frontmatter.part,
+      order: mdxTopic.frontmatter.order,
+      ...parseMdxSections(mdxTopic.content),
+    };
+  }
+
   const fs = await import("node:fs/promises");
   const filePath = path.join(CONTENT_ROOT, `${slug}.json`);
 
@@ -27,3 +35,71 @@ export const getTopicContentBySlug = cache(async (slug: string): Promise<TopicCo
     return null;
   }
 });
+
+function parseMdxSections(content: string): Pick<TopicContent, "blocks" | "sections"> {
+  const lines = content.split("\n");
+  const blocks: TopicContent["blocks"] = [];
+  const sections: NonNullable<TopicContent["sections"]> = [];
+  let currentMain: string | null = null;
+  let currentSection: { id: string; title: string; lines: string[] } | null = null;
+  let buffer: string[] = [];
+
+  const flush = () => {
+    const text = buffer.join("\n").trim();
+    if (!text) {
+      buffer = [];
+      return;
+    }
+
+    if (currentSection) {
+      currentSection.lines.push(text);
+    } else if (currentMain) {
+      const type = currentMain === "Idea clave" ? "idea" : currentMain === "Mini explicación" ? "explain" : currentMain === "Ejemplo numérico (SI)" ? "example" : "formulas";
+      blocks.push({ type, title: currentMain, body: text, mono: type === "example" });
+    }
+
+    buffer = [];
+  };
+
+  for (const line of lines) {
+    const mainHeading = line.match(/^##\s+(.+)$/);
+    if (mainHeading) {
+      flush();
+      currentSection = null;
+      currentMain = mainHeading[1].trim();
+      continue;
+    }
+
+    const subHeading = line.match(/^###\s+(.+?)\s+\{#([\w-]+)\}\s*$/);
+    if (subHeading) {
+      flush();
+      if (currentSection) {
+        sections.push({
+          id: currentSection.id,
+          title: currentSection.title,
+          blocks: currentSection.lines.map((body, index) => ({ type: index === 0 ? "explain" : "example", title: index === 0 ? "Explicación" : "Ejemplo", body, mono: index > 0 })),
+        });
+      }
+      currentSection = { id: subHeading[2], title: subHeading[1], lines: [] };
+      continue;
+    }
+
+    if (!line.trim()) {
+      buffer.push("");
+      continue;
+    }
+
+    buffer.push(line.replace(/^\-\s+/, ""));
+  }
+
+  flush();
+  if (currentSection) {
+    sections.push({
+      id: currentSection.id,
+      title: currentSection.title,
+      blocks: currentSection.lines.map((body, index) => ({ type: index === 0 ? "explain" : "example", title: index === 0 ? "Explicación" : "Ejemplo", body, mono: index > 0 })),
+    });
+  }
+
+  return { blocks, sections: sections.length ? sections : undefined };
+}


### PR DESCRIPTION
### Motivation
- Move the Unidad "Electricidad" content from JSON placeholders into real MDX source files so content can be authored as MDX while keeping the site working during the migration. 
- Preserve existing sidebar anchors and navigation so existing links (including `#anchors`) keep working. 
- Keep backwards compatibility: if an MDX file is not present, continue to serve the current JSON content as a fallback.

### Description
- Added MDX topic files for the 16 requested topics under `src/content/electricidad/*.mdx` with the mandated frontmatter keys (`title`, `description`, `part`, `order`) and the required internal structure: `## Idea clave`, `## Mini explicación`, `## Ejemplo numérico (SI)` and `## Fórmulas` when applicable, plus explicit subtopic IDs (e.g. `{#por-frotamiento}`).
- Implemented MDX-first loading in `src/lib/content.ts` by using `getMdxBySlug` and a small parser `parseMdxSections` that converts MDX body into the existing `TopicContent` shape so the existing page renderer can reuse the same layout; JSON is used if no MDX exists.
- Added/updated `src/lib/mdx.ts` utilities for reading frontmatter and MDX content (simple parser); updated search index generation `scripts/generate-search-index.mjs` to include MDX body text (with JSON fallback) and regenerated `src/content/search-index.json`.
- Removed duplication by redirecting the temporary MDX route `src/app/unidad/electricidad-mdx/[slug]/page.tsx` to the canonical route `/unidad/electricidad/[slug]`.
- Documented the new source-of-truth process in `README.md` under "MDX source of truth" and included a short how-to for adding new topics.
- Explicitly did not author any new topical content: the MDX files contain the placeholders `PENDIENTE: ...` copied from the existing JSON files so no content was invented in this PR.

### Testing
- Ran the search index generation script: `node scripts/generate-search-index.mjs` and it completed successfully and wrote `src/content/search-index.json`.
- Ran lint: `npm run lint` succeeded (no blocking errors).
- Performed a production build: `npm run build` (runs `prebuild` which regenerates the search index) and `next build` completed successfully and all static/SSG topic pages were generated.
- Attempted an automated browser check to capture a screenshot of `/unidad/electricidad/metodos-electrificacion#por-frotamiento`, but Playwright Chromium/Firefox failed in this environment (runtime browser failures), so no screenshot was captured; this does not affect the build or server-side routing tests above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fd563b9ac832da5894a8de755f676)