### PR TITLE
Render matemáticas (LaTeX) + estilos

### DIFF
--- a/docs/mdx-math-and-cards.md
+++ b/docs/mdx-math-and-cards.md
@@ -6,6 +6,18 @@
   - Ejemplo: `$1\\,\\mu C = 10^{-6}\\,C$`
 - **Math de bloque**: usar `$$...$$` para fórmulas destacadas (multilínea permitida).
   - Ejemplo: `$$|F| = k \\frac{|q_1 q_2|}{r^2}$$`
+- **Math de bloque alternativa**: también se acepta `\\[ ... \\]`.
+  - Ejemplo: `\\[ F = (9 \\times 10^9)\\frac{(2 \\times 10^{-6})(3 \\times 10^{-6})}{(0{,}50)^2} = 0{,}216\\,N \\]`
+
+## Cómo escribir fórmulas (guía corta para autores)
+
+- Inline en texto normal: `La carga es $q=2\\,\\mu C$`.
+- Bloque centrado: usar `$$...$$` o `\\[...\\]` en una línea separada.
+- No escribir LaTeX “suelto” sin delimitadores (por ejemplo `|F| = k \\frac{|q_1 q_2|}{r^2}`), porque se verá como texto crudo.
+- Si querés mostrar código literal de LaTeX, usá backticks: `` `\\frac{a}{b}` `` para evitar render matemático.
+- Ejemplos correctos:
+  - `$|F| = k \\frac{|q_1 q_2|}{r^2}$`
+  - `$1\\,\\mu C = 10^{-6}\\,C$`
 
 ## Escapar símbolo `$` literal
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,3 +22,24 @@ body {
   color: var(--foreground);
   font-family: var(--font-sans), system-ui, sans-serif;
 }
+
+.katex {
+  font-size: 1.08em;
+}
+
+.katex-inline .katex {
+  line-height: 1.45;
+}
+
+.katex-block .katex-display {
+  margin: 0.5rem 0;
+}
+
+.katex-block {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(100, 116, 139, 0.6) transparent;
+}
+
+.dark .katex {
+  color: #e2e8f0;
+}

--- a/src/components/content/BlockMath.tsx
+++ b/src/components/content/BlockMath.tsx
@@ -24,15 +24,15 @@ export function BlockMath({ latex }: BlockMathProps) {
 
   if (!html) {
     return (
-      <div className="my-3 overflow-x-auto rounded-md bg-slate-100/80 px-3 py-2 font-mono text-sm dark:bg-slate-800/80">
+      <div className="my-4 overflow-x-auto rounded-md bg-slate-100/80 px-3 py-2 font-mono text-sm leading-relaxed dark:bg-slate-800/80">
         {latex}
       </div>
     );
   }
 
   return (
-    <div className="my-3 overflow-x-auto rounded-md bg-slate-100/80 px-3 py-2 dark:bg-slate-800/80">
-      <div dangerouslySetInnerHTML={{ __html: html }} />
+    <div className="katex-block my-4 overflow-x-auto rounded-md bg-slate-100/80 px-3 py-2 dark:bg-slate-800/80">
+      <div className="min-w-max" dangerouslySetInnerHTML={{ __html: html }} />
     </div>
   );
 }

--- a/src/components/content/InlineMath.tsx
+++ b/src/components/content/InlineMath.tsx
@@ -26,5 +26,5 @@ export function InlineMath({ latex }: InlineMathProps) {
     return <code className="rounded bg-slate-100 px-1 py-0.5 text-xs dark:bg-slate-800">{latex}</code>;
   }
 
-  return <span className="katex-inline" dangerouslySetInnerHTML={{ __html: html }} />;
+  return <span className="katex-inline text-[1.03em]" dangerouslySetInnerHTML={{ __html: html }} />;
 }

--- a/src/content/electricidad/ley-de-coulomb.mdx
+++ b/src/content/electricidad/ley-de-coulomb.mdx
@@ -16,8 +16,13 @@ La fuerza es directamente proporcional al producto de las cargas e inversamente 
 ## Ejemplo numérico (SI)
 
 Con q1 = +2 μC, q2 = +3 μC y r = 0,50 m:
-F = k |q1 q2| / r^2 = (9 × 10^9) (2 × 10^-6)(3 × 10^-6) / (0,50)^2 = 0,216 N.
+$|F| = k \frac{|q_1 q_2|}{r^2}$
+
+Y reemplazando valores:
+\[
+F = (9 \times 10^9)\frac{(2 \times 10^{-6})(3 \times 10^{-6})}{(0{,}50)^2} = 0{,}216\,N
+\]
 
 ## Fórmulas
 
-- F = k |q1 q2| / r^2
+- $|F| = k \frac{|q_1 q_2|}{r^2}$

--- a/src/content/search-index.json
+++ b/src/content/search-index.json
@@ -27,7 +27,7 @@
     "title": "Ley de Coulomb",
     "href": "/unidad/electricidad/ley-de-coulomb",
     "description": "Relación entre cargas y fuerza eléctrica.",
-    "bodyPlain": "La ley de Coulomb establece la magnitud de la fuerza eléctrica entre dos cargas puntuales. La fuerza es directamente proporcional al producto de las cargas e inversamente proporcional al cuadrado de la distancia que las separa. Con q1 = +2 μC, q2 = +3 μC y r = 0,50 m: F = k |q1 q2| / r^2 = (9 × 10^9) (2 × 10^-6)(3 × 10^-6) / (0,50)^2 = 0,216 N. F = k |q1 q2| / r^2"
+    "bodyPlain": "La ley de Coulomb establece la magnitud de la fuerza eléctrica entre dos cargas puntuales. La fuerza es directamente proporcional al producto de las cargas e inversamente proporcional al cuadrado de la distancia que las separa. Con q1 = +2 μC, q2 = +3 μC y r = 0,50 m: $|F| = k \\frac{|q_1 q_2|}{r^2}$ Y reemplazando valores: \\[ F = (9 \\times 10^9)\\frac{(2 \\times 10^{-6})(3 \\times 10^{-6})}{(0{,}50)^2} = 0{,}216\\,N \\] $|F| = k \\frac{|q_1 q_2|}{r^2}$"
   },
   {
     "title": "Fuerza eléctrica",


### PR DESCRIPTION
### Motivation
- Habilitar renderizado de fórmulas LaTeX en el renderer MDX propio para que fórmulas inline (`$...$`) y display (`$$...$$` o `\[...\]`) se muestren correctamente con KaTeX sin introducir una pipeline MDX externa. 
- Evitar que delimitadores matemáticos se interpreten dentro de código inline (backticks) y mejorar la legibilidad en modo oscuro y en pantallas pequeñas. 
- Proveer un par de ejemplos demostrativos y una guía corta para autores que indique cómo escribir fórmulas correctamente.

### Description
- Mejoré el tokenizador y parser de math en `src/lib/mathTokens.ts` para ignorar `$...$` dentro de backticks y para soportar bloques `\[...\]` además de `$$...$$`. 
- Ajusté los componentes de render de math: `src/components/content/InlineMath.tsx` aumentó ligeramente el tamaño inline y `src/components/content/BlockMath.tsx` añadió clases para márgenes, control de overflow y ancho mínimo (`min-w-max`) para evitar quiebres incorrectos. 
- Añadí reglas CSS en `src/app/globals.css` para tamaño/line-height de KaTeX, margenes de display y soporte de color en dark mode. 
- Convertí ejemplos mínimos en contenido: `src/content/electricidad/ley-de-coulomb.mdx` ahora usa delimitadores LaTeX inline y display para la ley de Coulomb y la conversión solicitada. 
- Documenté la sintaxis y una guía corta para autores en `docs/mdx-math-and-cards.md` y regeneré el índice de búsqueda (`src/content/search-index.json`) como parte del flujo de build.

### Testing
- Ejecuté `npm run lint` y el linteo finalizó sin errores. 
- Ejecuté `npm run test:parse-smoke` y la prueba de smoke del parser retornó `OK`. 
- Ejecuté `npm run build` y la construcción de producción se completó correctamente después de ajustar el uso de estilos (build falló inicialmente por una importación de CSS; se eliminó la importación problemática y el build terminó exitoso). 
- Validé visualmente con `npm run dev` y una captura automatizada de `/unidad/electricidad/ley-de-coulomb` que muestra las fórmulas renderizadas (artifact disponible en la ejecución).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ff8f48b3c832d89a3c874aedb85ae)