### PR TITLE
Render matemático real en bloques de fórmulas

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,4 @@
+@import "katex/dist/katex.min.css";
 @import "tailwindcss";
 
 :root {

--- a/src/components/content/BlockMath.tsx
+++ b/src/components/content/BlockMath.tsx
@@ -24,15 +24,15 @@ export function BlockMath({ latex }: BlockMathProps) {
 
   if (!html) {
     return (
-      <div className="my-3 overflow-x-auto rounded-md bg-slate-100/80 px-3 py-2 font-mono text-sm dark:bg-slate-800/80">
+      <div className="my-4 overflow-x-auto rounded-md border border-slate-200/80 bg-slate-50 px-3 py-2 font-mono text-sm dark:border-slate-700 dark:bg-slate-900/60">
         {latex}
       </div>
     );
   }
 
   return (
-    <div className="my-3 overflow-x-auto rounded-md bg-slate-100/80 px-3 py-2 dark:bg-slate-800/80">
-      <div dangerouslySetInnerHTML={{ __html: html }} />
+    <div className="my-4 overflow-x-auto rounded-md border border-slate-200/80 bg-white px-3 py-2 dark:border-slate-700 dark:bg-slate-950/40">
+      <div className="flex justify-center text-slate-900 dark:text-slate-100" dangerouslySetInnerHTML={{ __html: html }} />
     </div>
   );
 }

--- a/src/content/electricidad/ley-de-coulomb.mdx
+++ b/src/content/electricidad/ley-de-coulomb.mdx
@@ -15,9 +15,10 @@ La fuerza es directamente proporcional al producto de las cargas e inversamente 
 
 ## Ejemplo numérico (SI)
 
-Con q1 = +2 μC, q2 = +3 μC y r = 0,50 m:
-F = k |q1 q2| / r^2 = (9 × 10^9) (2 × 10^-6)(3 × 10^-6) / (0,50)^2 = 0,216 N.
+Con $q_1 = +2\,\mu\mathrm{C}$, $q_2 = +3\,\mu\mathrm{C}$ y $r = 0{,}50\,\mathrm{m}$:
+$1\,\mu\mathrm{C} = 10^{-6}\,\mathrm{C}$
+$F = k \frac{\left|q_1 q_2\right|}{r^2} = 0{,}216\,\mathrm{N}$.
 
 ## Fórmulas
 
-- F = k |q1 q2| / r^2
+$$F = k \frac{\left|q_1 q_2\right|}{r^2}$$

--- a/src/content/search-index.json
+++ b/src/content/search-index.json
@@ -27,7 +27,7 @@
     "title": "Ley de Coulomb",
     "href": "/unidad/electricidad/ley-de-coulomb",
     "description": "Relación entre cargas y fuerza eléctrica.",
-    "bodyPlain": "La ley de Coulomb establece la magnitud de la fuerza eléctrica entre dos cargas puntuales. La fuerza es directamente proporcional al producto de las cargas e inversamente proporcional al cuadrado de la distancia que las separa. Con q1 = +2 μC, q2 = +3 μC y r = 0,50 m: F = k |q1 q2| / r^2 = (9 × 10^9) (2 × 10^-6)(3 × 10^-6) / (0,50)^2 = 0,216 N. F = k |q1 q2| / r^2"
+    "bodyPlain": "La ley de Coulomb establece la magnitud de la fuerza eléctrica entre dos cargas puntuales. La fuerza es directamente proporcional al producto de las cargas e inversamente proporcional al cuadrado de la distancia que las separa. Con $q_1 = +2\\,\\mu\\mathrm{C}$, $q_2 = +3\\,\\mu\\mathrm{C}$ y $r = 0{,}50\\,\\mathrm{m}$: $1\\,\\mu\\mathrm{C} = 10^{-6}\\,\\mathrm{C}$ $F = k \\frac{\\left|q_1 q_2\\right|}{r^2} = 0{,}216\\,\\mathrm{N}$. $$F = k \\frac{\\left|q_1 q_2\\right|}{r^2}$$"
   },
   {
     "title": "Fuerza eléctrica",


### PR DESCRIPTION
### Motivation

- Mejorar la presentación de las fórmulas para que se vean “tipo libro” (fracciones, subíndices, etc.) en los bloques "Fórmulas" y en "Ejemplo numérico (SI)" sin romper rutas ni slugs existentes.
- Aplicar la solución mínima compatible con la base actual que ya usa KaTeX en server render, evitando migrar todo el pipeline MDX en este PR.

### Description

- Diagnóstico: el bloque “Fórmulas” se renderiza desde `src/components/content/cards/FormulaCard.tsx` (y “Ejemplo numérico (SI)” desde `EjemploCard`), ambos usando el renderer común `src/components/content/renderTokens.tsx`, y el contenido proviene de MDX con fallback JSON via `src/lib/content.ts`; los bloques no están envueltos en `<pre>`/`<code>` como contenedor principal aunque algunos bloques de ejemplo usan `font-mono`.
- KaTeX en código: el proyecto ya incluía llamadas a `katex.renderToString` (`InlineMath`/`BlockMath`) y la dependencia `katex` en `package.json`, pero no había import global del CSS de KaTeX, lo que degradaba la apariencia del HTML generado.
- Cambios técnicos principales: añadí la importación global `@import "katex/dist/katex.min.css"` en `src/app/globals.css`, mejoré el componente de display math (`src/components/content/BlockMath.tsx`) para centrar y estilizar la salida KaTeX y ajustar comportamiento en modo oscuro y móvil, y endurecí el tokenizador para no procesar math dentro de `inline code` ni dentro de fenced code y para soportar `\[...\]` además de `$$...$$` (`src/lib/mathTokens.ts`).
- Contenido demo y metadatos: actualicé un ejemplo mínimo en `src/content/electricidad/ley-de-coulomb.mdx` con inline y display math y regeneré el `src/content/search-index.json`, y extendí el smoke test de parsing en `scripts/parse-smoke-test.mjs` para cubrir inline code, fenced code y `\[...\]`.

### Testing

- Ejecuté `npm run test:parse-smoke`, pero la prueba no pudo finalizar porque el entorno no tenía `typescript` instalado (error `ERR_MODULE_NOT_FOUND`), por lo que la suite smoke no pasó en este entorno de ejecución.
- Intenté `npm run lint` y `npm run build`, pero ambas fallaron localmente porque las dependencias (incluyendo `eslint` y `next`) no pudieron instalarse en este entorno (registro npm devolvió `403 Forbidden`), impidiendo ejecutar lint/build reales aquí.
- El script `scripts/parse-smoke-test.mjs` fue actualizado y, en un entorno con dependencias instaladas, debería validar: tokenización que respeta `inline code`, no parseo dentro de fenced code, y parseo de `$$...$$` y `\[...\]` (nota: estos checks no pudieron ejecutarse con éxito aquí por las limitaciones de instalación).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990049e3c68832dbbd63f6f08b9da42)