### PR TITLE
docs: inventario de fórmulas para PR #1 (solo JSON/data)

### DIFF
--- a/docs/math-inventory-pr1.md
+++ b/docs/math-inventory-pr1.md
@@ -1,0 +1,45 @@
+# Inventario de fórmulas — PR #1 (JSON/data)
+
+Fecha: 2026-02-14
+
+## Alcance
+- Se revisaron temas en `src/content/electricidad` para detectar patrones LaTeX típicos:
+  - `\frac`, `\mu`, `\times`, `^{`, `_{`, `\left`, `\right`, `\vec`.
+  - magnitudes con barras tipo `|...|`.
+- El inventario se hizo separando:
+  - A) `.mdx`
+  - B) `.json` (fallback legado)
+- Se ignoró contenido dentro de fenced code e inline code para evitar falsos positivos.
+
+## Resultado global
+- **Temas totales con fórmulas detectadas:** **3**
+- **MDX:** **3 temas (100%)**
+- **JSON fallback:** **0 temas (0%)**
+
+## Distribución por sección de render
+- **MDX / Fórmulas:** 5 ocurrencias
+- **MDX / Ejemplo numérico (SI):** 4 ocurrencias
+- **MDX / Explicación:** 0 ocurrencias
+- **MDX / otros:** 0 ocurrencias
+- **JSON / todas las secciones:** 0 ocurrencias
+
+## Ejemplos de fórmulas problemáticas (3–5)
+1. `$$|F| = k \frac{|q_1 q_2|}{r^2}$$`  
+   - Problema: magnitud con `|...|` sin `\left|...\right|`.
+2. `Conversión útil en notación científica: $1\,\mu C = 10^{-6}\,C$.`  
+   - Problema: unidades sin `\mathrm{}` en algunos casos.
+3. `Si un cuerpo queda con $q = -2\,\mu C$, en unidades SI se escribe $q = -2 \times 10^{-6}\,C$.`  
+   - Problema: mezcla de notación con y sin `\mathrm{}`.
+4. `- F = k |q1 q2| / r^2`  
+   - Problema: fórmula cruda no delimitada en sección de Fórmulas.
+5. `$F = k\,\frac{\left|q_1 q_2\right|}{r^2} = (9 \times 10^9)\,\frac{(2 \times 10^{-6})(3 \times 10^{-6})}{(0{,}50)^2} = 0{,}216\,\mathrm{N}$.`  
+   - Estado: ya está bien delimitada y con `\mathrm{}` (referencia positiva).
+
+## Implementación PR #1 (solo JSON/data)
+- Se revisaron todos los `.json` de fallback en `src/content/electricidad`.
+- **Archivos JSON modificados:** **0**
+- **Campos JSON modificados:** **0**
+- Motivo: actualmente los JSON están en estado plantilla (`PENDIENTE`) y no contienen fórmulas para estandarizar todavía.
+
+## Nota operativa para PR #2 (MDX)
+La migración real de delimitadores y normalización (display vs inline, `\left|\right|`, `\mathrm{}`) se realizará sobre MDX en PR separado, para mantener cambios pequeños y trazables.


### PR DESCRIPTION
### Motivation
- Inventariar ocurrencias de LaTeX en el contenido para planear una migración incremental de KaTeX sin romper rutas ni code blocks.
- Detectar si el trabajo inicial (PR #1) sobre datos JSON/fallback requiere modificaciones o si la migración debe hacerse sobre MDX en PRs posteriores.

### Description
- Agrego `docs/math-inventory-pr1.md` con el reporte del inventario realizado en `src/content/electricidad` y las reglas de búsqueda aplicadas (patrones como `\frac`, `\mu`, `\times`, `^{`, `_{`, `\left`, `\right`, `\vec` y barras `|...|`).
- El reporte resume que se detectaron **3** temas con fórmulas, todos en `MDX` (3 temas, 100%) y **0** en JSON (0%), y desglosa ocurrencias por sección: `MDX / Fórmulas` = 5 y `MDX / Ejemplo numérico (SI)` = 4.
- Incluye 5 ejemplos representativos de fórmulas problemáticas y una nota operativa que PR #1 no cambia JSON (0 archivos/campos modificados) y que la normalización se realizará en PR #2 sobre MDX.
- No se tocaron rutas, slugs, parser ni contenido MDX en este PR; solo cambios documentales en `docs/math-inventory-pr1.md`.

### Testing
- Ran `npm run lint` which failed due to missing local dependency `eslint` so lint could not complete (expected in this environment).
- Ran `npm run test:parse-smoke` which failed due to missing dependency `typescript` so the parser smoke test could not complete (expected in this environment).
- Ran `npm run build` which executed `prebuild` and regenerated the search index (28 entries) but `next build` failed because `next` is not available in the environment; index regeneration succeeded.
- Summary: validations partially executed (search-index generation ok) but `lint`, `test:parse-smoke` and full `build` did not succeed due to absent dev dependencies in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699008073900832d91dba37da7d10e94)