### PR TITLE
Mejora legibilidad en modo claro y elimina fondo gris en fórmulas

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  --background: #f8fafc;
+  --background: #f4f7fb;
   --foreground: #0f172a;
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -58,14 +58,15 @@ export default function HomePage() {
       <section className="space-y-6">
         <Badge>Unidad activa</Badge>
         <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Consulta de Electrotecnia</h1>
-        <p className="max-w-3xl text-slate-600 dark:text-slate-300">
+        <p className="max-w-3xl text-slate-700 dark:text-slate-300">
           Esta wiki está pensada para estudiantes que necesitan entender, repasar y practicar Electricidad de forma
           ordenada. Podés recorrerla en secuencia como curso breve o usarla como apunte rápido por tema.
         </p>
-        <div className="max-w-3xl rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
+        <div className="max-w-3xl rounded-xl border border-slate-300 bg-white p-4 text-sm text-slate-800 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
           Encontrarás explicaciones breves, fórmulas clave y ejemplos numéricos para conectar teoría con resolución de
           problemas.
         </div>
+        <p className="text-sm font-medium text-slate-700 dark:text-slate-300">Esta Wiki es un servicio de INGENIUM.</p>
         <Button asChild>
           <Link href="/unidad/electricidad">Ir a Unidad: Electricidad</Link>
         </Button>
@@ -81,7 +82,7 @@ export default function HomePage() {
             return (
               <Card key={item.slug} className="flex h-full flex-col">
                 <h3 className="text-lg font-semibold">{item.title}</h3>
-                <p className="mt-2 flex-1 text-sm text-slate-600 dark:text-slate-300">{item.description}</p>
+                <p className="mt-2 flex-1 text-sm text-slate-700 dark:text-slate-300">{item.description}</p>
                 <Button asChild variant="outline" className="mt-4 w-full justify-center">
                   <Link href={href}>Abrir tema</Link>
                 </Button>
@@ -91,9 +92,9 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="space-y-3 rounded-xl border border-slate-200 p-5 dark:border-slate-800">
+      <section className="space-y-3 rounded-xl border border-slate-300 bg-white/90 p-5 shadow-sm dark:border-slate-800 dark:bg-slate-950">
         <h2 className="text-2xl font-semibold tracking-tight">Cómo estudiar con esta wiki</h2>
-        <ul className="space-y-2 text-sm text-slate-700 dark:text-slate-300">
+        <ul className="space-y-2 text-sm text-slate-800 dark:text-slate-300">
           {studyTips.map((tip) => (
             <li key={tip} className="flex gap-2">
               <span aria-hidden="true" className="mt-1 text-slate-400">•</span>

--- a/src/app/unidad/electricidad/[slug]/page.tsx
+++ b/src/app/unidad/electricidad/[slug]/page.tsx
@@ -58,16 +58,16 @@ export default async function ElectricidadTopicPage({ params }: PageProps) {
 
   return (
     <article className="space-y-6">
-      <header className="space-y-2 border-b border-slate-200 pb-6 dark:border-slate-800">
+      <header className="space-y-2 border-b border-slate-300 pb-6 dark:border-slate-800">
         <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Parte {topic.part}</p>
         <h1 className="text-3xl font-bold tracking-tight">{topic.title}</h1>
-        <p className="text-slate-600 dark:text-slate-300">{topic.description}</p>
+        <p className="text-slate-700 dark:text-slate-300">{topic.description}</p>
       </header>
 
       {topic.blocks.map((block, index) => <BlockCard key={`${block.type}-${index}`} block={block} />)}
 
       {topic.sections?.map((section) => (
-        <section key={section.id} id={section.id} className="scroll-mt-24 space-y-4 rounded-xl border border-slate-200 p-5 dark:border-slate-800">
+        <section key={section.id} id={section.id} className="scroll-mt-24 space-y-4 rounded-xl border border-slate-300 bg-white/95 p-5 shadow-sm dark:border-slate-800 dark:bg-transparent">
           <h2 className="text-xl font-semibold">{section.title}</h2>
           {section.blocks.map((block, index) => <BlockCard key={`${section.id}-${block.type}-${index}`} block={block} />)}
         </section>

--- a/src/components/content/BlockMath.tsx
+++ b/src/components/content/BlockMath.tsx
@@ -21,14 +21,14 @@ export function BlockMath({ latex }: BlockMathProps) {
 
   if (!html) {
     return (
-      <div className="my-3 overflow-x-auto rounded-md bg-slate-100/80 px-3 py-2 font-mono text-sm dark:bg-slate-800/80">
+      <div className="my-3 overflow-x-auto rounded-md px-2 py-2 font-mono text-sm dark:bg-slate-800/80 dark:px-3">
         {latex}
       </div>
     );
   }
 
   return (
-    <div className="my-3 overflow-x-auto rounded-md bg-slate-100/80 px-3 py-2 dark:bg-slate-800/80">
+    <div className="my-3 overflow-x-auto rounded-md px-2 py-2 dark:bg-slate-800/80 dark:px-3">
       <div className="min-w-max" dangerouslySetInnerHTML={{ __html: html }} />
     </div>
   );

--- a/src/components/content/cards/EjemploCard.tsx
+++ b/src/components/content/cards/EjemploCard.tsx
@@ -7,7 +7,7 @@ type EjemploCardProps = {
 
 export function EjemploCard({ block }: EjemploCardProps) {
   return (
-    <section className="rounded-xl border border-violet-200 bg-violet-50/70 p-5 shadow-sm dark:border-violet-900 dark:bg-violet-950/30">
+    <section className="rounded-xl border border-violet-200 bg-violet-50/90 p-5 shadow-sm dark:border-violet-900 dark:bg-violet-950/30">
       <h2 className="text-lg font-semibold text-violet-900 dark:text-violet-100">{block.title}</h2>
       {renderContentNodes(block.nodes ?? [], block.body, true)}
     </section>

--- a/src/components/content/cards/ExplicacionCard.tsx
+++ b/src/components/content/cards/ExplicacionCard.tsx
@@ -7,7 +7,7 @@ type ExplicacionCardProps = {
 
 export function ExplicacionCard({ block }: ExplicacionCardProps) {
   return (
-    <section className="rounded-xl border border-emerald-200 bg-emerald-50/70 p-5 shadow-sm dark:border-emerald-900 dark:bg-emerald-950/30">
+    <section className="rounded-xl border border-emerald-200 bg-emerald-50/90 p-5 shadow-sm dark:border-emerald-900 dark:bg-emerald-950/30">
       <h2 className="text-lg font-semibold text-emerald-900 dark:text-emerald-100">{block.title}</h2>
       {renderContentNodes(block.nodes ?? [], block.body, block.mono)}
     </section>

--- a/src/components/content/cards/FormulaCard.tsx
+++ b/src/components/content/cards/FormulaCard.tsx
@@ -7,11 +7,11 @@ type FormulaCardProps = {
 
 export function FormulaCard({ block }: FormulaCardProps) {
   return (
-    <section className="rounded-xl border border-amber-200 bg-amber-50/70 p-5 shadow-sm dark:border-amber-900 dark:bg-amber-950/30">
+    <section className="rounded-xl border border-amber-200 bg-amber-50/90 p-5 shadow-sm dark:border-amber-900 dark:bg-amber-950/30">
       <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100">{block.title}</h2>
       {renderContentNodes(block.nodes ?? [], block.body, block.mono)}
       {block.items?.length ? (
-        <ul className="mt-3 list-disc space-y-1 pl-5 text-slate-700 dark:text-slate-300">
+        <ul className="mt-3 list-disc space-y-1 pl-5 text-slate-800 dark:text-slate-300">
           {block.items.map((item) => (
             <li key={item} className="font-mono text-sm">{item}</li>
           ))}

--- a/src/components/content/cards/IdeaClaveCard.tsx
+++ b/src/components/content/cards/IdeaClaveCard.tsx
@@ -7,7 +7,7 @@ type IdeaClaveCardProps = {
 
 export function IdeaClaveCard({ block }: IdeaClaveCardProps) {
   return (
-    <section className="rounded-xl border border-sky-200 bg-sky-50/70 p-5 shadow-sm dark:border-sky-900 dark:bg-sky-950/30">
+    <section className="rounded-xl border border-sky-200 bg-sky-50/90 p-5 shadow-sm dark:border-sky-900 dark:bg-sky-950/30">
       <h2 className="text-lg font-semibold text-sky-900 dark:text-sky-100">{block.title}</h2>
       {renderContentNodes(block.nodes ?? [], block.body, block.mono)}
     </section>

--- a/src/components/content/renderTokens.tsx
+++ b/src/components/content/renderTokens.tsx
@@ -18,7 +18,7 @@ export function renderInlineTokens(tokens: InlineToken[]): ReactNode[] {
 
 export function renderContentNodes(nodes: ContentNode[], fallbackBody?: string, mono?: boolean): ReactNode {
   if (!nodes.length) {
-    return fallbackBody ? <p className={mono ? "mt-2 font-mono text-sm whitespace-pre-wrap" : "mt-2 text-slate-700 dark:text-slate-300 whitespace-pre-wrap"}>{fallbackBody}</p> : null;
+    return fallbackBody ? <p className={mono ? "mt-2 font-mono text-sm whitespace-pre-wrap" : "mt-2 text-slate-800 dark:text-slate-300 whitespace-pre-wrap"}>{fallbackBody}</p> : null;
   }
 
   return nodes.map((node, index) => {
@@ -27,7 +27,7 @@ export function renderContentNodes(nodes: ContentNode[], fallbackBody?: string, 
     }
 
     return (
-      <p key={`paragraph-${index}`} className={node.mono ? "mt-2 font-mono text-sm whitespace-pre-wrap" : "mt-2 text-slate-700 dark:text-slate-300 whitespace-pre-wrap"}>
+      <p key={`paragraph-${index}`} className={node.mono ? "mt-2 font-mono text-sm whitespace-pre-wrap" : "mt-2 text-slate-800 dark:text-slate-300 whitespace-pre-wrap"}>
         {renderInlineTokens(node.tokens)}
       </p>
     );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -10,12 +10,12 @@ export async function Header() {
   const searchIndex = await getSearchIndex();
 
   return (
-    <header className="border-b border-slate-200 bg-white/90 backdrop-blur dark:border-slate-800 dark:bg-slate-950/90">
+    <header className="border-b border-slate-300 bg-white/95 backdrop-blur dark:border-slate-800 dark:bg-slate-950/90">
       <div className="mx-auto flex h-16 w-full max-w-7xl items-center gap-3 px-4 sm:px-6 lg:px-8">
         <Link href="/" className="text-base font-bold tracking-tight sm:text-lg">
           {siteConfig.name}
         </Link>
-        <nav className="hidden items-center gap-4 text-sm text-slate-600 dark:text-slate-300 md:flex">
+        <nav className="hidden items-center gap-4 text-sm text-slate-700 dark:text-slate-300 md:flex">
           <Link href="/unidad/electricidad" className="hover:text-slate-900 dark:hover:text-white">
             Unidad: Electricidad
           </Link>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -43,7 +43,7 @@ function NodeItem({
           node.isPage && "font-medium",
           active
             ? "bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900"
-            : "text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white",
+            : "text-slate-700 hover:bg-slate-200 hover:text-slate-950 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white",
         )}
       >
         {node.title}

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -6,7 +6,7 @@ export function Card({ className, ...props }: CardProps) {
   return (
     <div
       className={cn(
-        "rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900",
+        "rounded-xl border border-slate-300 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900",
         className,
       )}
       {...props}

--- a/src/components/ui/Collapsible.tsx
+++ b/src/components/ui/Collapsible.tsx
@@ -16,7 +16,7 @@ export function Collapsible({ title, children, defaultOpen = false, className }:
   const contentId = useId();
 
   return (
-    <section className={cn("rounded-lg border border-slate-200 p-2 dark:border-slate-800", className)}>
+    <section className={cn("rounded-lg border border-slate-300 bg-white/90 p-2 shadow-sm dark:border-slate-800", className)}>
       <button
         type="button"
         className="flex w-full items-center justify-between px-1 py-1 text-left text-sm font-semibold"
@@ -25,7 +25,7 @@ export function Collapsible({ title, children, defaultOpen = false, className }:
         onClick={() => setOpen((value) => !value)}
       >
         {title}
-        <span className="text-xs text-slate-500">{open ? "Ocultar" : "Mostrar"}</span>
+        <span className="text-xs text-slate-600">{open ? "Ocultar" : "Mostrar"}</span>
       </button>
       {open ? (
         <div id={contentId} className="pt-2">


### PR DESCRIPTION
### Motivation
- Mejorar la legibilidad en el modo claro ajustando colores, bordes y superficies para que el texto y las tarjetas no se vean lavados.
- Quitar el fondo gris de los bloques de fórmulas para que las expresiones KaTeX se integren mejor en el diseño en light mode.
- Añadir identificador institucional en la portada para mostrar que la wiki es un servicio de INGENIUM.

### Description
- Se eliminó el fondo gris de los bloques de fórmulas y se simplificó el padding en `src/components/content/BlockMath.tsx` para light mode mientras se mantiene el estilo en dark mode. 
- Se ajustó el color de fondo base en `src/app/globals.css` y se mejoró contraste de textos y superficies en `src/app/page.tsx` añadiendo la línea `Esta Wiki es un servicio de INGENIUM.`. 
- Se incrementó contraste y suavizó bordes/sombras en elementos de UI en `src/components/layout/Header.tsx`, `src/components/layout/Sidebar.tsx`, `src/components/ui/Card.tsx` y `src/components/ui/Collapsible.tsx`. 
- Se subió contraste de textos y fondos en las tarjetas de contenido y renderizado de nodos en `src/components/content/cards/*` y `src/components/content/renderTokens.tsx` para mejor lectura en light mode.

### Testing
- `node scripts/generate-search-index.mjs` (ejecutado como paso `prebuild`) generó exitosamente 28 entradas en `src/content/search-index.json`.
- `npm run lint` fue ejecutado pero falló por falta de dependencias en el entorno (no se encontró `eslint`).
- `npm run test:parse-smoke` fue ejecutado pero falló por falta de dependencias en el entorno (no se encontró `typescript`).
- `npm run build` / `npm run dev` no pudieron completarse porque `next` no está disponible en el entorno y la instalación de dependencias está bloqueada por políticas del registry (`npm install` devolvió 403), por lo que no se pudo levantar una instancia local para pruebas visuales.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69900d60c5a0832d97c1d122acbac3ca)