### PR TITLE
Mejorar legibilidad en modo claro y quitar fondo gris en fórmulas

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  --background: #f8fafc;
+  --background: #ffffff;
   --foreground: #0f172a;
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -58,11 +58,14 @@ export default function HomePage() {
       <section className="space-y-6">
         <Badge>Unidad activa</Badge>
         <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Consulta de Electrotecnia</h1>
-        <p className="max-w-3xl text-slate-600 dark:text-slate-300">
+        <p className="text-sm font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-400">
+          Esta Wiki es un servicio de INGENIUM.
+        </p>
+        <p className="max-w-3xl text-slate-700 dark:text-slate-300">
           Esta wiki está pensada para estudiantes que necesitan entender, repasar y practicar Electricidad de forma
           ordenada. Podés recorrerla en secuencia como curso breve o usarla como apunte rápido por tema.
         </p>
-        <div className="max-w-3xl rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
+        <div className="max-w-3xl rounded-xl border border-slate-300 bg-white p-4 text-sm text-slate-800 shadow-sm dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
           Encontrarás explicaciones breves, fórmulas clave y ejemplos numéricos para conectar teoría con resolución de
           problemas.
         </div>
@@ -81,7 +84,7 @@ export default function HomePage() {
             return (
               <Card key={item.slug} className="flex h-full flex-col">
                 <h3 className="text-lg font-semibold">{item.title}</h3>
-                <p className="mt-2 flex-1 text-sm text-slate-600 dark:text-slate-300">{item.description}</p>
+                <p className="mt-2 flex-1 text-sm text-slate-700 dark:text-slate-300">{item.description}</p>
                 <Button asChild variant="outline" className="mt-4 w-full justify-center">
                   <Link href={href}>Abrir tema</Link>
                 </Button>
@@ -91,9 +94,9 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="space-y-3 rounded-xl border border-slate-200 p-5 dark:border-slate-800">
+      <section className="space-y-3 rounded-xl border border-slate-300 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-950">
         <h2 className="text-2xl font-semibold tracking-tight">Cómo estudiar con esta wiki</h2>
-        <ul className="space-y-2 text-sm text-slate-700 dark:text-slate-300">
+        <ul className="space-y-2 text-sm text-slate-800 dark:text-slate-300">
           {studyTips.map((tip) => (
             <li key={tip} className="flex gap-2">
               <span aria-hidden="true" className="mt-1 text-slate-400">•</span>

--- a/src/app/unidad/electricidad/[slug]/page.tsx
+++ b/src/app/unidad/electricidad/[slug]/page.tsx
@@ -61,7 +61,7 @@ export default async function ElectricidadTopicPage({ params }: PageProps) {
       <header className="space-y-2 border-b border-slate-200 pb-6 dark:border-slate-800">
         <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Parte {topic.part}</p>
         <h1 className="text-3xl font-bold tracking-tight">{topic.title}</h1>
-        <p className="text-slate-600 dark:text-slate-300">{topic.description}</p>
+        <p className="text-slate-700 dark:text-slate-300">{topic.description}</p>
       </header>
 
       {topic.blocks.map((block, index) => <BlockCard key={`${block.type}-${index}`} block={block} />)}

--- a/src/components/content/BlockMath.tsx
+++ b/src/components/content/BlockMath.tsx
@@ -21,14 +21,14 @@ export function BlockMath({ latex }: BlockMathProps) {
 
   if (!html) {
     return (
-      <div className="my-3 overflow-x-auto rounded-md bg-slate-100/80 px-3 py-2 font-mono text-sm dark:bg-slate-800/80">
+      <div className="my-3 overflow-x-auto rounded-md border border-slate-200 px-3 py-2 font-mono text-sm text-slate-800 dark:border-slate-700 dark:text-slate-100">
         {latex}
       </div>
     );
   }
 
   return (
-    <div className="my-3 overflow-x-auto rounded-md bg-slate-100/80 px-3 py-2 dark:bg-slate-800/80">
+    <div className="my-3 overflow-x-auto rounded-md border border-slate-200 px-3 py-2 dark:border-slate-700">
       <div className="min-w-max" dangerouslySetInnerHTML={{ __html: html }} />
     </div>
   );

--- a/src/components/content/renderTokens.tsx
+++ b/src/components/content/renderTokens.tsx
@@ -18,7 +18,7 @@ export function renderInlineTokens(tokens: InlineToken[]): ReactNode[] {
 
 export function renderContentNodes(nodes: ContentNode[], fallbackBody?: string, mono?: boolean): ReactNode {
   if (!nodes.length) {
-    return fallbackBody ? <p className={mono ? "mt-2 font-mono text-sm whitespace-pre-wrap" : "mt-2 text-slate-700 dark:text-slate-300 whitespace-pre-wrap"}>{fallbackBody}</p> : null;
+    return fallbackBody ? <p className={mono ? "mt-2 font-mono text-sm whitespace-pre-wrap" : "mt-2 text-slate-800 dark:text-slate-300 whitespace-pre-wrap"}>{fallbackBody}</p> : null;
   }
 
   return nodes.map((node, index) => {
@@ -27,7 +27,7 @@ export function renderContentNodes(nodes: ContentNode[], fallbackBody?: string, 
     }
 
     return (
-      <p key={`paragraph-${index}`} className={node.mono ? "mt-2 font-mono text-sm whitespace-pre-wrap" : "mt-2 text-slate-700 dark:text-slate-300 whitespace-pre-wrap"}>
+      <p key={`paragraph-${index}`} className={node.mono ? "mt-2 font-mono text-sm whitespace-pre-wrap" : "mt-2 text-slate-800 dark:text-slate-300 whitespace-pre-wrap"}>
         {renderInlineTokens(node.tokens)}
       </p>
     );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -10,12 +10,12 @@ export async function Header() {
   const searchIndex = await getSearchIndex();
 
   return (
-    <header className="border-b border-slate-200 bg-white/90 backdrop-blur dark:border-slate-800 dark:bg-slate-950/90">
+    <header className="border-b border-slate-200 bg-white/95 backdrop-blur dark:border-slate-800 dark:bg-slate-950/90">
       <div className="mx-auto flex h-16 w-full max-w-7xl items-center gap-3 px-4 sm:px-6 lg:px-8">
         <Link href="/" className="text-base font-bold tracking-tight sm:text-lg">
           {siteConfig.name}
         </Link>
-        <nav className="hidden items-center gap-4 text-sm text-slate-600 dark:text-slate-300 md:flex">
+        <nav className="hidden items-center gap-4 text-sm text-slate-700 dark:text-slate-300 md:flex">
           <Link href="/unidad/electricidad" className="hover:text-slate-900 dark:hover:text-white">
             Unidad: Electricidad
           </Link>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -43,7 +43,7 @@ function NodeItem({
           node.isPage && "font-medium",
           active
             ? "bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900"
-            : "text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white",
+            : "text-slate-700 hover:bg-slate-100 hover:text-slate-950 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white",
         )}
       >
         {node.title}

--- a/src/components/ui/Collapsible.tsx
+++ b/src/components/ui/Collapsible.tsx
@@ -16,7 +16,7 @@ export function Collapsible({ title, children, defaultOpen = false, className }:
   const contentId = useId();
 
   return (
-    <section className={cn("rounded-lg border border-slate-200 p-2 dark:border-slate-800", className)}>
+    <section className={cn("rounded-lg border border-slate-300 bg-white p-2 dark:border-slate-800 dark:bg-slate-950", className)}>
       <button
         type="button"
         className="flex w-full items-center justify-between px-1 py-1 text-left text-sm font-semibold"
@@ -25,7 +25,7 @@ export function Collapsible({ title, children, defaultOpen = false, className }:
         onClick={() => setOpen((value) => !value)}
       >
         {title}
-        <span className="text-xs text-slate-500">{open ? "Ocultar" : "Mostrar"}</span>
+        <span className="text-xs text-slate-600 dark:text-slate-400">{open ? "Ocultar" : "Mostrar"}</span>
       </button>
       {open ? (
         <div id={contentId} className="pt-2">


### PR DESCRIPTION
### Motivation
- Mejorar la legibilidad del modo claro incrementando contraste y limpiando superficies para que el contenido sea más fácil de leer. 
- Eliminar el fondo gris de los bloques de fórmulas para que las expresiones KaTeX encajen mejor con el diseño claro. 
- Añadir en la portada el aviso requerido: "Esta Wiki es un servicio de INGENIUM.".

### Description
- Cambié el fondo global en `src/app/globals.css` a blanco puro y reforcé colores de primer plano para modo claro. 
- Reemplacé el fondo gris de KaTeX en `src/components/content/BlockMath.tsx` por un contenedor con borde neutro y texto en tono oscuro, incluyendo el fallback. 
- Mejoré contraste de textos y superficies en la portada y páginas de tema modificando `src/app/page.tsx` y `src/app/unidad/electricidad/[slug]/page.tsx`. 
- Ajusté renderizado de contenido, navegación y colapsables para modo claro en `src/components/content/renderTokens.tsx`, `src/components/layout/Header.tsx`, `src/components/layout/Sidebar.tsx` y `src/components/ui/Collapsible.tsx`.

### Testing
- `prebuild` (ejecutado como parte de `npm run build`) generó el índice en `src/content/search-index.json` correctamente. 
- `npm run lint` falló por dependencias faltantes en el entorno (`eslint` no está instalado). 
- `npm run test:parse-smoke` falló por dependencias faltantes (`typescript` no está instalado). 
- `npm run build` no completó porque `next` no está disponible en el entorno, y el paso de screenshot con Playwright falló por crash del navegador en el contenedor (SIGSEGV).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69900d60c5a0832d97c1d122acbac3ca)