### PR TITLE
style: ajustar fondo del tema claro a crema cálida

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,8 @@
 @import "tailwindcss";
 
 :root {
-  --background: #f8fafc;
+  /* Paleta clara inspirada en INGENIUM (crema cálido). */
+  --background: #f6f0e2;
   --foreground: #0f172a;
 }
 


### PR DESCRIPTION
### Motivation
- Mejorar el contraste percibido del tema claro y acercar la paleta visual al estilo de INGENIUM cambiando el token global de fondo.

### Description
- Se actualizó el token `--background` en `src/app/globals.css` de `#f8fafc` a `#f6f0e2`, sin tocar los valores del tema oscuro.

### Testing
- Intenté ejecutar `npm run lint` (falló por `eslint` no instalado), `npm ci` (falló por `403` al resolver `katex`) y `npm run dev` (no arrancó porque `next` no está disponible sin dependencias), por lo que no fue posible validar la visualización en este entorno.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69908d2d3f74832dbff848de9aeb193f)