### PR TITLE
Adjust light theme background to a cream tone

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 :root {
-  --background: #f8fafc;
+  --background: #f7f0e2;
   --foreground: #0f172a;
 }
 


### PR DESCRIPTION
### Motivation
- Improve contrast and visual warmth of the light theme to better match the INGENIUM aesthetic while leaving dark mode unchanged.

### Description
- Updated the CSS color token `--background` in `src/app/globals.css` from `#f8fafc` to a warmer cream `#f7f0e2` so the app `body` background adopts the new tone.

### Testing
- Ran `npm run lint` which failed in this environment due to a missing `eslint` dependency; no lint pass available.
- Ran `npm run build` where the prebuild step generated the search index but `next build` failed because `next` is not installed in the environment.
- Attempted `npm install` but it was blocked by the registry with a `403 Forbidden` (package resolution failure for `katex`), so full dependency installation and build could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69908d2d3f74832dbff848de9aeb193f)