### PR TITLE
Mejora contraste del tema claro: tipografías más oscuras en la portada

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,15 @@
 @import "tailwindcss";
 
 :root {
-  --background: #f8fafc;
+  /* Paleta clara base (crema suave, alineada con estética INGENIUM) */
+  --background: #f7f1e6;
   --foreground: #0f172a;
+
+  /* Alternativas claras para ajustar el tono sin tocar componentes:
+   * Opción A (más neutra): #f5efe3
+   * Opción B (más cálida): #f4ecdc
+   * Opción C (más luminosa): #faf5ea
+   */
 }
 
 .dark {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -58,7 +58,7 @@ export default function HomePage() {
       <section className="space-y-6">
         <Badge>Unidad activa</Badge>
         <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Consulta de Electrotecnia</h1>
-        <p className="max-w-3xl text-slate-600 dark:text-slate-300">
+        <p className="max-w-3xl text-slate-800 dark:text-slate-300">
           Esta wiki está pensada para estudiantes que necesitan entender, repasar y practicar Electricidad de forma
           ordenada. Podés recorrerla en secuencia como curso breve o usarla como apunte rápido por tema.
         </p>
@@ -81,7 +81,7 @@ export default function HomePage() {
             return (
               <Card key={item.slug} className="flex h-full flex-col">
                 <h3 className="text-lg font-semibold">{item.title}</h3>
-                <p className="mt-2 flex-1 text-sm text-slate-600 dark:text-slate-300">{item.description}</p>
+                <p className="mt-2 flex-1 text-sm text-slate-800 dark:text-slate-300">{item.description}</p>
                 <Button asChild variant="outline" className="mt-4 w-full justify-center">
                   <Link href={href}>Abrir tema</Link>
                 </Button>
@@ -93,10 +93,10 @@ export default function HomePage() {
 
       <section className="space-y-3 rounded-xl border border-slate-200 p-5 dark:border-slate-800">
         <h2 className="text-2xl font-semibold tracking-tight">Cómo estudiar con esta wiki</h2>
-        <ul className="space-y-2 text-sm text-slate-700 dark:text-slate-300">
+        <ul className="space-y-2 text-sm text-slate-800 dark:text-slate-300">
           {studyTips.map((tip) => (
             <li key={tip} className="flex gap-2">
-              <span aria-hidden="true" className="mt-1 text-slate-400">•</span>
+              <span aria-hidden="true" className="mt-1 text-slate-500">•</span>
               <span>{tip}</span>
             </li>
           ))}


### PR DESCRIPTION
### Motivation
- Ajustar la legibilidad tras cambiar el fondo claro a crema porque el texto de apoyo quedó demasiado tenue sobre el nuevo fondo.
- Priorizar cambios locales en la portada para resolver el problema sin afectar el modo oscuro ni componentes globales.

### Description
- Actualiza la paleta clara en `src/app/globals.css` cambiando `--background` a `#f7f1e6` y añade tres alternativas comentadas (`#f5efe3`, `#f4ecdc`, `#faf5ea`).
- Oscurece textos secundarios en la portada en `src/app/page.tsx`: `text-slate-600` -> `text-slate-800` para el párrafo principal y las descripciones de tarjetas.
- Ajusta la lista de consejos en la portada en `src/app/page.tsx` de `text-slate-700` -> `text-slate-800` y la viñeta de `text-slate-400` -> `text-slate-500`.
- Los cambios buscan mejorar contraste en bloques de lectura sin tocar estilos en `dark`.

### Testing
- Ejecuté `npm run build` donde el `prebuild` ejecutó `node scripts/generate-search-index.mjs` y generó `src/content/search-index.json` (éxito); la fase `next build` falló porque `next` no está instalado (`next: not found`).
- Ejecuté `npm run lint` y falló con `Cannot find package 'eslint'` debido a dependencias no instaladas (falla).
- Intenté captura con Playwright accediendo a `http://127.0.0.1:3000` y falló con `ERR_EMPTY_RESPONSE` porque no se pudo levantar el servidor en este entorno (falla/indisponible).
- No se ejecutaron tests unitarios adicionales por las dependencias del entorno; los cambios son principalmente de estilo y se pueden validar visualmente al levantar la app localmente con dependencias instaladas (`npm ci`) y luego `npm run dev`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69908d2d3f74832dbff848de9aeb193f)