### PR TITLE
Mejora contraste de tipografías en el tema claro

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,15 @@
 @import "tailwindcss";
 
 :root {
-  --background: #f8fafc;
+  /* Paleta clara base (crema suave, alineada con estética INGENIUM) */
+  --background: #f7f1e6;
   --foreground: #0f172a;
+
+  /* Alternativas claras para ajustar el tono sin tocar componentes:
+   * Opción A (más neutra): #f5efe3
+   * Opción B (más cálida): #f4ecdc
+   * Opción C (más luminosa): #faf5ea
+   */
 }
 
 .dark {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -58,7 +58,7 @@ export default function HomePage() {
       <section className="space-y-6">
         <Badge>Unidad activa</Badge>
         <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Consulta de Electrotecnia</h1>
-        <p className="max-w-3xl text-slate-600 dark:text-slate-300">
+        <p className="max-w-3xl text-slate-800 dark:text-slate-300">
           Esta wiki está pensada para estudiantes que necesitan entender, repasar y practicar Electricidad de forma
           ordenada. Podés recorrerla en secuencia como curso breve o usarla como apunte rápido por tema.
         </p>
@@ -81,7 +81,7 @@ export default function HomePage() {
             return (
               <Card key={item.slug} className="flex h-full flex-col">
                 <h3 className="text-lg font-semibold">{item.title}</h3>
-                <p className="mt-2 flex-1 text-sm text-slate-600 dark:text-slate-300">{item.description}</p>
+                <p className="mt-2 flex-1 text-sm text-slate-800 dark:text-slate-300">{item.description}</p>
                 <Button asChild variant="outline" className="mt-4 w-full justify-center">
                   <Link href={href}>Abrir tema</Link>
                 </Button>
@@ -93,10 +93,10 @@ export default function HomePage() {
 
       <section className="space-y-3 rounded-xl border border-slate-200 p-5 dark:border-slate-800">
         <h2 className="text-2xl font-semibold tracking-tight">Cómo estudiar con esta wiki</h2>
-        <ul className="space-y-2 text-sm text-slate-700 dark:text-slate-300">
+        <ul className="space-y-2 text-sm text-slate-800 dark:text-slate-300">
           {studyTips.map((tip) => (
             <li key={tip} className="flex gap-2">
-              <span aria-hidden="true" className="mt-1 text-slate-400">•</span>
+              <span aria-hidden="true" className="mt-1 text-slate-600">•</span>
               <span>{tip}</span>
             </li>
           ))}

--- a/src/app/unidad/electricidad-mdx/[slug]/page.tsx
+++ b/src/app/unidad/electricidad-mdx/[slug]/page.tsx
@@ -41,9 +41,9 @@ export default async function ElectricidadMdxPage({ params }: PageProps) {
   return (
     <article className="space-y-6">
       <header className="space-y-2 border-b border-slate-200 pb-6 dark:border-slate-800">
-        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Vista de prueba MDX</p>
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-400">Vista de prueba MDX</p>
         <h1 className="text-3xl font-bold tracking-tight">{topic.title}</h1>
-        <p className="text-slate-600 dark:text-slate-300">{topic.description}</p>
+        <p className="text-slate-800 dark:text-slate-300">{topic.description}</p>
       </header>
 
       {!standardMdx.enabled && process.env.NODE_ENV !== "production" ? (

--- a/src/app/unidad/electricidad/[slug]/page.tsx
+++ b/src/app/unidad/electricidad/[slug]/page.tsx
@@ -59,9 +59,9 @@ export default async function ElectricidadTopicPage({ params }: PageProps) {
   return (
     <article className="space-y-6">
       <header className="space-y-2 border-b border-slate-200 pb-6 dark:border-slate-800">
-        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Parte {topic.part}</p>
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-400">Parte {topic.part}</p>
         <h1 className="text-3xl font-bold tracking-tight">{topic.title}</h1>
-        <p className="text-slate-600 dark:text-slate-300">{topic.description}</p>
+        <p className="text-slate-800 dark:text-slate-300">{topic.description}</p>
       </header>
 
       {topic.blocks.map((block, index) => <BlockCard key={`${block.type}-${index}`} block={block} />)}

--- a/src/app/unidad/electricidad/page.tsx
+++ b/src/app/unidad/electricidad/page.tsx
@@ -23,20 +23,20 @@ export default function ElectricidadIndexPage() {
     <div className="space-y-8">
       <header className="space-y-2">
         <h1 className="text-3xl font-bold tracking-tight">Unidad: Electricidad</h1>
-        <p className="text-slate-600 dark:text-slate-300">Wiki/apunte rápido para estudiar en orden todos los temas de la unidad.</p>
+        <p className="text-slate-800 dark:text-slate-300">Wiki/apunte rápido para estudiar en orden todos los temas de la unidad.</p>
       </header>
 
       <div className="grid gap-4 md:grid-cols-2">
         <Card>
           <h2 className="text-xl font-semibold">Parte 1</h2>
-          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">Electricidad básica: cargas, campos y potencial.</p>
+          <p className="mt-2 text-sm text-slate-800 dark:text-slate-300">Electricidad básica: cargas, campos y potencial.</p>
           <p className="mt-3 text-xs text-slate-500">Progreso: 0/{sections[0]?.children.length ?? 0} temas.</p>
           {firstPart1 ? <Button asChild className="mt-4"><Link href={firstPart1.href}>Comenzar Parte 1</Link></Button> : null}
         </Card>
 
         <Card>
           <h2 className="text-xl font-semibold">Parte 2</h2>
-          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">Electricidad en circuitos: magnitudes y leyes fundamentales.</p>
+          <p className="mt-2 text-sm text-slate-800 dark:text-slate-300">Electricidad en circuitos: magnitudes y leyes fundamentales.</p>
           <p className="mt-3 text-xs text-slate-500">Progreso: 0/{sections[1]?.children.length ?? 0} temas.</p>
           {firstPart2 ? <Button asChild className="mt-4"><Link href={firstPart2.href}>Comenzar Parte 2</Link></Button> : null}
         </Card>


### PR DESCRIPTION
### Motivation
- Tras cambiar el fondo a una paleta crema quedó texto secundario con contraste insuficiente en el tema claro, afectando la legibilidad. 
- El objetivo es aumentar el contraste de las tipografías en páginas clave sin tocar el tema oscuro ni la estructura de rutas.

### Description
- Se reforzó el color de textos descriptivos y secundarios en varias vistas del sitio pasando variantes claras (`text-slate-600/700/500/400`) a tonos más oscuros (`text-slate-800` y `text-slate-600`) en modo claro para mejorar legibilidad. 
- Se actualizó el color del bullet en la lista de recomendaciones de la home para que no quede demasiado tenue en el nuevo fondo crema. 
- Se mantuvo intacto el comportamiento en modo oscuro (`dark:*`), y no se cambiaron slugs, anchors ni la estructura de navegación. 
- Archivos modificados: `src/app/globals.css`, `src/app/page.tsx`, `src/app/unidad/electricidad/page.tsx`, `src/app/unidad/electricidad/[slug]/page.tsx`, `src/app/unidad/electricidad-mdx/[slug]/page.tsx`.

### Testing
- Ejecuté `node scripts/generate-search-index.mjs` como parte de `npm run build` y se generaron 28 entradas en `src/content/search-index.json` correctamente. 
- `npm run lint` falló por falta de dependencias en el entorno con el error `Cannot find package 'eslint'`. 
- `npm run build` falló en la fase `next build` porque `next` no está instalado en este entorno, aunque la fase previa de generación de índice se completó. 
- Intento de ver/validar visualmente con Playwright falló al acceder a `http://127.0.0.1:3000` (`ERR_EMPTY_RESPONSE`) porque no había servidor Next.js activo en el entorno.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69908d2d3f74832dbff848de9aeb193f)