### PR TITLE
Corrige contraste del menú lateral en tema claro

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,15 @@
 @import "tailwindcss";
 
 :root {
-  --background: #f8fafc;
+  /* Paleta clara base (crema suave, alineada con estética INGENIUM) */
+  --background: #f7f1e6;
   --foreground: #0f172a;
+
+  /* Alternativas claras para ajustar el tono sin tocar componentes:
+   * Opción A (más neutra): #f5efe3
+   * Opción B (más cálida): #f4ecdc
+   * Opción C (más luminosa): #faf5ea
+   */
 }
 
 .dark {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -58,7 +58,7 @@ export default function HomePage() {
       <section className="space-y-6">
         <Badge>Unidad activa</Badge>
         <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Consulta de Electrotecnia</h1>
-        <p className="max-w-3xl text-slate-600 dark:text-slate-300">
+        <p className="max-w-3xl text-slate-800 dark:text-slate-300">
           Esta wiki está pensada para estudiantes que necesitan entender, repasar y practicar Electricidad de forma
           ordenada. Podés recorrerla en secuencia como curso breve o usarla como apunte rápido por tema.
         </p>
@@ -81,7 +81,7 @@ export default function HomePage() {
             return (
               <Card key={item.slug} className="flex h-full flex-col">
                 <h3 className="text-lg font-semibold">{item.title}</h3>
-                <p className="mt-2 flex-1 text-sm text-slate-600 dark:text-slate-300">{item.description}</p>
+                <p className="mt-2 flex-1 text-sm text-slate-800 dark:text-slate-300">{item.description}</p>
                 <Button asChild variant="outline" className="mt-4 w-full justify-center">
                   <Link href={href}>Abrir tema</Link>
                 </Button>
@@ -93,10 +93,10 @@ export default function HomePage() {
 
       <section className="space-y-3 rounded-xl border border-slate-200 p-5 dark:border-slate-800">
         <h2 className="text-2xl font-semibold tracking-tight">Cómo estudiar con esta wiki</h2>
-        <ul className="space-y-2 text-sm text-slate-700 dark:text-slate-300">
+        <ul className="space-y-2 text-sm text-slate-800 dark:text-slate-300">
           {studyTips.map((tip) => (
             <li key={tip} className="flex gap-2">
-              <span aria-hidden="true" className="mt-1 text-slate-400">•</span>
+              <span aria-hidden="true" className="mt-1 text-slate-500">•</span>
               <span>{tip}</span>
             </li>
           ))}

--- a/src/app/unidad/electricidad-mdx/[slug]/page.tsx
+++ b/src/app/unidad/electricidad-mdx/[slug]/page.tsx
@@ -41,9 +41,9 @@ export default async function ElectricidadMdxPage({ params }: PageProps) {
   return (
     <article className="space-y-6">
       <header className="space-y-2 border-b border-slate-200 pb-6 dark:border-slate-800">
-        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Vista de prueba MDX</p>
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-400">Vista de prueba MDX</p>
         <h1 className="text-3xl font-bold tracking-tight">{topic.title}</h1>
-        <p className="text-slate-600 dark:text-slate-300">{topic.description}</p>
+        <p className="text-slate-800 dark:text-slate-300">{topic.description}</p>
       </header>
 
       {!standardMdx.enabled && process.env.NODE_ENV !== "production" ? (

--- a/src/app/unidad/electricidad/[slug]/page.tsx
+++ b/src/app/unidad/electricidad/[slug]/page.tsx
@@ -59,9 +59,9 @@ export default async function ElectricidadTopicPage({ params }: PageProps) {
   return (
     <article className="space-y-6">
       <header className="space-y-2 border-b border-slate-200 pb-6 dark:border-slate-800">
-        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Parte {topic.part}</p>
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-400">Parte {topic.part}</p>
         <h1 className="text-3xl font-bold tracking-tight">{topic.title}</h1>
-        <p className="text-slate-600 dark:text-slate-300">{topic.description}</p>
+        <p className="text-slate-800 dark:text-slate-300">{topic.description}</p>
       </header>
 
       {topic.blocks.map((block, index) => <BlockCard key={`${block.type}-${index}`} block={block} />)}

--- a/src/app/unidad/electricidad/page.tsx
+++ b/src/app/unidad/electricidad/page.tsx
@@ -23,20 +23,20 @@ export default function ElectricidadIndexPage() {
     <div className="space-y-8">
       <header className="space-y-2">
         <h1 className="text-3xl font-bold tracking-tight">Unidad: Electricidad</h1>
-        <p className="text-slate-600 dark:text-slate-300">Wiki/apunte rápido para estudiar en orden todos los temas de la unidad.</p>
+        <p className="text-slate-800 dark:text-slate-300">Wiki/apunte rápido para estudiar en orden todos los temas de la unidad.</p>
       </header>
 
       <div className="grid gap-4 md:grid-cols-2">
         <Card>
           <h2 className="text-xl font-semibold">Parte 1</h2>
-          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">Electricidad básica: cargas, campos y potencial.</p>
+          <p className="mt-2 text-sm text-slate-800 dark:text-slate-300">Electricidad básica: cargas, campos y potencial.</p>
           <p className="mt-3 text-xs text-slate-500">Progreso: 0/{sections[0]?.children.length ?? 0} temas.</p>
           {firstPart1 ? <Button asChild className="mt-4"><Link href={firstPart1.href}>Comenzar Parte 1</Link></Button> : null}
         </Card>
 
         <Card>
           <h2 className="text-xl font-semibold">Parte 2</h2>
-          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">Electricidad en circuitos: magnitudes y leyes fundamentales.</p>
+          <p className="mt-2 text-sm text-slate-800 dark:text-slate-300">Electricidad en circuitos: magnitudes y leyes fundamentales.</p>
           <p className="mt-3 text-xs text-slate-500">Progreso: 0/{sections[1]?.children.length ?? 0} temas.</p>
           {firstPart2 ? <Button asChild className="mt-4"><Link href={firstPart2.href}>Comenzar Parte 2</Link></Button> : null}
         </Card>

--- a/src/components/content/renderTokens.tsx
+++ b/src/components/content/renderTokens.tsx
@@ -18,7 +18,7 @@ export function renderInlineTokens(tokens: InlineToken[]): ReactNode[] {
 
 export function renderContentNodes(nodes: ContentNode[], fallbackBody?: string, mono?: boolean): ReactNode {
   if (!nodes.length) {
-    return fallbackBody ? <p className={mono ? "mt-2 font-mono text-sm whitespace-pre-wrap" : "mt-2 text-slate-700 dark:text-slate-300 whitespace-pre-wrap"}>{fallbackBody}</p> : null;
+    return fallbackBody ? <p className={mono ? "mt-2 font-mono text-sm whitespace-pre-wrap" : "mt-2 text-slate-800 dark:text-slate-300 whitespace-pre-wrap"}>{fallbackBody}</p> : null;
   }
 
   return nodes.map((node, index) => {
@@ -27,7 +27,7 @@ export function renderContentNodes(nodes: ContentNode[], fallbackBody?: string, 
     }
 
     return (
-      <p key={`paragraph-${index}`} className={node.mono ? "mt-2 font-mono text-sm whitespace-pre-wrap" : "mt-2 text-slate-700 dark:text-slate-300 whitespace-pre-wrap"}>
+      <p key={`paragraph-${index}`} className={node.mono ? "mt-2 font-mono text-sm whitespace-pre-wrap" : "mt-2 text-slate-800 dark:text-slate-300 whitespace-pre-wrap"}>
         {renderInlineTokens(node.tokens)}
       </p>
     );

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -43,7 +43,7 @@ function NodeItem({
           node.isPage && "font-medium",
           active
             ? "bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900"
-            : "text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white",
+            : "text-slate-900 hover:bg-slate-100 hover:text-slate-950 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white",
         )}
       >
         {node.title}

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -21,13 +21,13 @@ export function SearchResults({ items, emptyText, onSelect }: SearchResultsProps
                 className="block rounded-md px-2 py-1.5 hover:bg-slate-100 dark:hover:bg-slate-800"
               >
                 <p className="text-sm font-medium">{item.title}</p>
-                <p className="line-clamp-1 text-xs text-slate-600 dark:text-slate-300">{item.description}</p>
+                <p className="line-clamp-1 text-xs text-slate-800 dark:text-slate-300">{item.description}</p>
               </Link>
             </li>
           ))}
         </ul>
       ) : (
-        <p className="px-2 py-1 text-sm text-slate-500 dark:text-slate-400">{emptyText}</p>
+        <p className="px-2 py-1 text-sm text-slate-600 dark:text-slate-400">{emptyText}</p>
       )}
     </div>
   );

--- a/src/components/ui/Collapsible.tsx
+++ b/src/components/ui/Collapsible.tsx
@@ -19,13 +19,13 @@ export function Collapsible({ title, children, defaultOpen = false, className }:
     <section className={cn("rounded-lg border border-slate-200 p-2 dark:border-slate-800", className)}>
       <button
         type="button"
-        className="flex w-full items-center justify-between px-1 py-1 text-left text-sm font-semibold"
+        className="flex w-full items-center justify-between px-1 py-1 text-left text-sm font-semibold text-slate-900 dark:text-slate-100"
         aria-expanded={open}
         aria-controls={contentId}
         onClick={() => setOpen((value) => !value)}
       >
         {title}
-        <span className="text-xs text-slate-500">{open ? "Ocultar" : "Mostrar"}</span>
+        <span className="text-xs text-slate-700 dark:text-slate-300">{open ? "Ocultar" : "Mostrar"}</span>
       </button>
       {open ? (
         <div id={contentId} className="pt-2">


### PR DESCRIPTION
### Motivation
- La navegación lateral quedó con textos auxiliares casi ilegibles sobre el nuevo fondo crema y las modificaciones previas no resolvieron el problema en el sidebar; hace falta un ajuste puntual y seguro que recupere legibilidad.

### Description
- En `src/components/layout/Sidebar.tsx` los ítems inactivos pasaron de `text-slate-600` a `text-slate-900` y el `hover` en claro se reforzó con `hover:text-slate-950`, manteniendo los estilos para el estado activo y el modo oscuro.
- En `src/components/ui/Collapsible.tsx` el título del botón ahora fuerza `text-slate-900` en claro y se ajustó la etiqueta de acción `Ocultar/Mostrar` de `text-slate-500` a `text-slate-700` con su variante `dark:text-slate-300` para mejorar contraste.
- El cambio es intencionalmente focalizado en la zona señalada (lista de temas del sidebar) para restaurar la jerarquía visual sin afectar el comportamiento del colapsable ni el modo oscuro.

### Testing
- `npm run lint` se ejecutó y falló debido a que `eslint` no está instalado en el entorno (dependencia ausente).
- `npm run test:parse-smoke` falló por ausencia de `typescript` en el entorno (dependencia ausente).
- `npm run build` ejecutó el `prebuild` que generó `src/content/search-index.json` pero `next build` falló porque `next` no está instalado (`next: not found`).
- Intento de captura con Playwright no fue posible porque no hay servidor local funcional (`ERR_EMPTY_RESPONSE` al acceder a `http://127.0.0.1:3000`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69908d2d3f74832dbff848de9aeb193f)