### PR TITLE
Mejorar contraste claro/oscuro: migrar colores hardcode a tokens semánticos

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,16 +3,55 @@
 :root {
   --background: #f8fafc;
   --foreground: #0f172a;
+  --muted: #f1f5f9;
+  --muted-foreground: #475569;
+  --card: #ffffff;
+  --card-foreground: #0f172a;
+  --border: #e2e8f0;
+  --input: #cbd5e1;
+  --ring: #94a3b8;
+  --accent: #e2e8f0;
+  --accent-foreground: #0f172a;
+  --primary: #0f172a;
+  --primary-foreground: #f8fafc;
+  --secondary: #e2e8f0;
+  --secondary-foreground: #0f172a;
 }
 
 .dark {
   --background: #020617;
   --foreground: #e2e8f0;
+  --muted: #0f172a;
+  --muted-foreground: #94a3b8;
+  --card: #020617;
+  --card-foreground: #e2e8f0;
+  --border: #1e293b;
+  --input: #334155;
+  --ring: #475569;
+  --accent: #1e293b;
+  --accent-foreground: #e2e8f0;
+  --primary: #e2e8f0;
+  --primary-foreground: #0f172a;
+  --secondary: #1e293b;
+  --secondary-foreground: #e2e8f0;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
   --font-sans: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --font-mono: "JetBrains Mono", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,7 +36,7 @@ export default function RootLayout({
           <div className="min-h-screen bg-background text-foreground">
             <Header />
             <div className="pb-12">{children}</div>
-            <footer className="border-t border-slate-200 py-4 text-center text-sm text-slate-500 dark:border-slate-800">
+            <footer className="border-t border-border py-4 text-center text-sm text-muted-foreground">
               Material de consulta (Electrotecnia)
             </footer>
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -58,11 +58,11 @@ export default function HomePage() {
       <section className="space-y-6">
         <Badge>Unidad activa</Badge>
         <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Consulta de Electrotecnia</h1>
-        <p className="max-w-3xl text-slate-600 dark:text-slate-300">
+        <p className="max-w-3xl text-muted-foreground">
           Esta wiki está pensada para estudiantes que necesitan entender, repasar y practicar Electricidad de forma
           ordenada. Podés recorrerla en secuencia como curso breve o usarla como apunte rápido por tema.
         </p>
-        <div className="max-w-3xl rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
+        <div className="max-w-3xl rounded-xl border border-border bg-muted p-4 text-sm text-muted-foreground">
           Encontrarás explicaciones breves, fórmulas clave y ejemplos numéricos para conectar teoría con resolución de
           problemas.
         </div>
@@ -81,7 +81,7 @@ export default function HomePage() {
             return (
               <Card key={item.slug} className="flex h-full flex-col">
                 <h3 className="text-lg font-semibold">{item.title}</h3>
-                <p className="mt-2 flex-1 text-sm text-slate-600 dark:text-slate-300">{item.description}</p>
+                <p className="mt-2 flex-1 text-sm text-muted-foreground">{item.description}</p>
                 <Button asChild variant="outline" className="mt-4 w-full justify-center">
                   <Link href={href}>Abrir tema</Link>
                 </Button>
@@ -91,12 +91,12 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="space-y-3 rounded-xl border border-slate-200 p-5 dark:border-slate-800">
+      <section className="space-y-3 rounded-xl border border-border p-5">
         <h2 className="text-2xl font-semibold tracking-tight">Cómo estudiar con esta wiki</h2>
-        <ul className="space-y-2 text-sm text-slate-700 dark:text-slate-300">
+        <ul className="space-y-2 text-sm text-muted-foreground">
           {studyTips.map((tip) => (
             <li key={tip} className="flex gap-2">
-              <span aria-hidden="true" className="mt-1 text-slate-400">•</span>
+              <span aria-hidden="true" className="mt-1 text-muted-foreground">•</span>
               <span>{tip}</span>
             </li>
           ))}

--- a/src/app/unidad/electricidad-mdx/[slug]/page.tsx
+++ b/src/app/unidad/electricidad-mdx/[slug]/page.tsx
@@ -40,10 +40,10 @@ export default async function ElectricidadMdxPage({ params }: PageProps) {
 
   return (
     <article className="space-y-6">
-      <header className="space-y-2 border-b border-slate-200 pb-6 dark:border-slate-800">
-        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Vista de prueba MDX</p>
+      <header className="space-y-2 border-b border-border pb-6">
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Vista de prueba MDX</p>
         <h1 className="text-3xl font-bold tracking-tight">{topic.title}</h1>
-        <p className="text-slate-600 dark:text-slate-300">{topic.description}</p>
+        <p className="text-muted-foreground">{topic.description}</p>
       </header>
 
       {!standardMdx.enabled && process.env.NODE_ENV !== "production" ? (
@@ -62,7 +62,7 @@ export default async function ElectricidadMdxPage({ params }: PageProps) {
       {topic.blocks.map((block, index) => <BlockCard key={`${block.type}-${index}`} block={block} />)}
 
       {topic.sections?.map((section) => (
-        <section key={section.id} id={section.id} className="scroll-mt-24 space-y-4 rounded-xl border border-slate-200 p-5 dark:border-slate-800">
+        <section key={section.id} id={section.id} className="scroll-mt-24 space-y-4 rounded-xl border border-border p-5">
           <h2 className="text-xl font-semibold">{section.title}</h2>
           {section.blocks.map((block, index) => <BlockCard key={`${section.id}-${block.type}-${index}`} block={block} />)}
         </section>

--- a/src/app/unidad/electricidad/[slug]/page.tsx
+++ b/src/app/unidad/electricidad/[slug]/page.tsx
@@ -58,16 +58,16 @@ export default async function ElectricidadTopicPage({ params }: PageProps) {
 
   return (
     <article className="space-y-6">
-      <header className="space-y-2 border-b border-slate-200 pb-6 dark:border-slate-800">
-        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Parte {topic.part}</p>
+      <header className="space-y-2 border-b border-border pb-6">
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Parte {topic.part}</p>
         <h1 className="text-3xl font-bold tracking-tight">{topic.title}</h1>
-        <p className="text-slate-600 dark:text-slate-300">{topic.description}</p>
+        <p className="text-muted-foreground">{topic.description}</p>
       </header>
 
       {topic.blocks.map((block, index) => <BlockCard key={`${block.type}-${index}`} block={block} />)}
 
       {topic.sections?.map((section) => (
-        <section key={section.id} id={section.id} className="scroll-mt-24 space-y-4 rounded-xl border border-slate-200 p-5 dark:border-slate-800">
+        <section key={section.id} id={section.id} className="scroll-mt-24 space-y-4 rounded-xl border border-border p-5">
           <h2 className="text-xl font-semibold">{section.title}</h2>
           {section.blocks.map((block, index) => <BlockCard key={`${section.id}-${block.type}-${index}`} block={block} />)}
         </section>

--- a/src/app/unidad/electricidad/page.tsx
+++ b/src/app/unidad/electricidad/page.tsx
@@ -23,30 +23,30 @@ export default function ElectricidadIndexPage() {
     <div className="space-y-8">
       <header className="space-y-2">
         <h1 className="text-3xl font-bold tracking-tight">Unidad: Electricidad</h1>
-        <p className="text-slate-600 dark:text-slate-300">Wiki/apunte rápido para estudiar en orden todos los temas de la unidad.</p>
+        <p className="text-muted-foreground">Wiki/apunte rápido para estudiar en orden todos los temas de la unidad.</p>
       </header>
 
       <div className="grid gap-4 md:grid-cols-2">
         <Card>
           <h2 className="text-xl font-semibold">Parte 1</h2>
-          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">Electricidad básica: cargas, campos y potencial.</p>
-          <p className="mt-3 text-xs text-slate-500">Progreso: 0/{sections[0]?.children.length ?? 0} temas.</p>
+          <p className="mt-2 text-sm text-muted-foreground">Electricidad básica: cargas, campos y potencial.</p>
+          <p className="mt-3 text-xs text-muted-foreground">Progreso: 0/{sections[0]?.children.length ?? 0} temas.</p>
           {firstPart1 ? <Button asChild className="mt-4"><Link href={firstPart1.href}>Comenzar Parte 1</Link></Button> : null}
         </Card>
 
         <Card>
           <h2 className="text-xl font-semibold">Parte 2</h2>
-          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">Electricidad en circuitos: magnitudes y leyes fundamentales.</p>
-          <p className="mt-3 text-xs text-slate-500">Progreso: 0/{sections[1]?.children.length ?? 0} temas.</p>
+          <p className="mt-2 text-sm text-muted-foreground">Electricidad en circuitos: magnitudes y leyes fundamentales.</p>
+          <p className="mt-3 text-xs text-muted-foreground">Progreso: 0/{sections[1]?.children.length ?? 0} temas.</p>
           {firstPart2 ? <Button asChild className="mt-4"><Link href={firstPart2.href}>Comenzar Parte 2</Link></Button> : null}
         </Card>
       </div>
 
-      <section className="rounded-xl border border-slate-200 p-5 dark:border-slate-800">
+      <section className="rounded-xl border border-border p-5">
         <h2 className="text-xl font-semibold">Glosario de unidades</h2>
         <ul className="mt-3 flex flex-wrap gap-2">
           {glossary.map((item) => (
-            <li key={item} className="rounded-md border border-slate-300 px-3 py-1 font-mono text-sm dark:border-slate-700">{item}</li>
+            <li key={item} className="rounded-md border border-border bg-muted px-3 py-1 font-mono text-sm">{item}</li>
           ))}
         </ul>
       </section>

--- a/src/components/content/BlockMath.tsx
+++ b/src/components/content/BlockMath.tsx
@@ -21,14 +21,14 @@ export function BlockMath({ latex }: BlockMathProps) {
 
   if (!html) {
     return (
-      <div className="my-3 overflow-x-auto rounded-md bg-slate-100/80 px-3 py-2 font-mono text-sm dark:bg-slate-800/80">
+      <div className="my-3 overflow-x-auto rounded-md bg-muted px-3 py-2 font-mono text-sm text-muted-foreground">
         {latex}
       </div>
     );
   }
 
   return (
-    <div className="my-3 overflow-x-auto rounded-md bg-slate-100/80 px-3 py-2 dark:bg-slate-800/80">
+    <div className="my-3 overflow-x-auto rounded-md bg-muted px-3 py-2">
       <div className="min-w-max" dangerouslySetInnerHTML={{ __html: html }} />
     </div>
   );

--- a/src/components/content/InlineMath.tsx
+++ b/src/components/content/InlineMath.tsx
@@ -20,7 +20,7 @@ export function InlineMath({ latex }: InlineMathProps) {
   const html = tryRenderInlineMath(latex);
 
   if (!html) {
-    return <code className="rounded bg-slate-100 px-1 py-0.5 text-xs dark:bg-slate-800">{latex}</code>;
+    return <code className="rounded bg-muted px-1 py-0.5 text-xs text-muted-foreground">{latex}</code>;
   }
 
   return <span className="katex-inline" dangerouslySetInnerHTML={{ __html: html }} />;

--- a/src/components/content/cards/FormulaCard.tsx
+++ b/src/components/content/cards/FormulaCard.tsx
@@ -11,7 +11,7 @@ export function FormulaCard({ block }: FormulaCardProps) {
       <h2 className="text-lg font-semibold text-amber-900 dark:text-amber-100">{block.title}</h2>
       {renderContentNodes(block.nodes ?? [], block.body, block.mono)}
       {block.items?.length ? (
-        <ul className="mt-3 list-disc space-y-1 pl-5 text-slate-700 dark:text-slate-300">
+        <ul className="mt-3 list-disc space-y-1 pl-5 text-muted-foreground">
           {block.items.map((item) => (
             <li key={item} className="font-mono text-sm">{item}</li>
           ))}

--- a/src/components/content/renderTokens.tsx
+++ b/src/components/content/renderTokens.tsx
@@ -18,7 +18,7 @@ export function renderInlineTokens(tokens: InlineToken[]): ReactNode[] {
 
 export function renderContentNodes(nodes: ContentNode[], fallbackBody?: string, mono?: boolean): ReactNode {
   if (!nodes.length) {
-    return fallbackBody ? <p className={mono ? "mt-2 font-mono text-sm whitespace-pre-wrap" : "mt-2 text-slate-700 dark:text-slate-300 whitespace-pre-wrap"}>{fallbackBody}</p> : null;
+    return fallbackBody ? <p className={mono ? "mt-2 font-mono text-sm whitespace-pre-wrap" : "mt-2 text-muted-foreground whitespace-pre-wrap"}>{fallbackBody}</p> : null;
   }
 
   return nodes.map((node, index) => {
@@ -27,7 +27,7 @@ export function renderContentNodes(nodes: ContentNode[], fallbackBody?: string, 
     }
 
     return (
-      <p key={`paragraph-${index}`} className={node.mono ? "mt-2 font-mono text-sm whitespace-pre-wrap" : "mt-2 text-slate-700 dark:text-slate-300 whitespace-pre-wrap"}>
+      <p key={`paragraph-${index}`} className={node.mono ? "mt-2 font-mono text-sm whitespace-pre-wrap" : "mt-2 text-muted-foreground whitespace-pre-wrap"}>
         {renderInlineTokens(node.tokens)}
       </p>
     );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -10,13 +10,13 @@ export async function Header() {
   const searchIndex = await getSearchIndex();
 
   return (
-    <header className="border-b border-slate-200 bg-white/90 backdrop-blur dark:border-slate-800 dark:bg-slate-950/90">
+    <header className="border-b border-border bg-background/90 backdrop-blur">
       <div className="mx-auto flex h-16 w-full max-w-7xl items-center gap-3 px-4 sm:px-6 lg:px-8">
         <Link href="/" className="text-base font-bold tracking-tight sm:text-lg">
           {siteConfig.name}
         </Link>
-        <nav className="hidden items-center gap-4 text-sm text-slate-600 dark:text-slate-300 md:flex">
-          <Link href="/unidad/electricidad" className="hover:text-slate-900 dark:hover:text-white">
+        <nav className="hidden items-center gap-4 text-sm text-muted-foreground md:flex">
+          <Link href="/unidad/electricidad" className="hover:text-foreground">
             Unidad: Electricidad
           </Link>
         </nav>

--- a/src/components/layout/MobileDrawer.tsx
+++ b/src/components/layout/MobileDrawer.tsx
@@ -15,8 +15,8 @@ export function MobileDrawer() {
       </Button>
 
       {open ? (
-        <div className="fixed inset-0 z-50 bg-black/40" role="dialog" aria-modal="true">
-          <div className="h-full w-[85%] max-w-sm overflow-y-auto bg-white p-4 dark:bg-slate-950">
+        <div className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm" role="dialog" aria-modal="true">
+          <div className="h-full w-[85%] max-w-sm overflow-y-auto border-r border-border bg-card p-4 text-card-foreground">
             <div className="mb-4 flex items-center justify-between">
               <h2 className="text-sm font-semibold">Indice</h2>
               <Button type="button" variant="ghost" onClick={() => setOpen(false)}>

--- a/src/components/layout/PrevNext.tsx
+++ b/src/components/layout/PrevNext.tsx
@@ -15,7 +15,7 @@ export function PrevNext({ prev, next }: PrevNextProps) {
   }
 
   return (
-    <nav className="mt-12 grid gap-3 border-t border-slate-200 pt-6 dark:border-slate-800 sm:grid-cols-2">
+    <nav className="mt-12 grid gap-3 border-t border-border pt-6 sm:grid-cols-2">
       <div>
         {prev ? (
           <Button asChild variant="outline" className="w-full justify-start">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -42,8 +42,8 @@ function NodeItem({
           depth > 0 && "ml-3",
           node.isPage && "font-medium",
           active
-            ? "bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900"
-            : "text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white",
+            ? "bg-accent text-foreground font-semibold"
+            : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
         )}
       >
         {node.title}

--- a/src/components/search/SearchResults.tsx
+++ b/src/components/search/SearchResults.tsx
@@ -10,7 +10,7 @@ type SearchResultsProps = {
 
 export function SearchResults({ items, emptyText, onSelect }: SearchResultsProps) {
   return (
-    <div className="absolute right-0 z-20 mt-2 w-full rounded-lg border border-slate-200 bg-white p-2 shadow-lg dark:border-slate-800 dark:bg-slate-900">
+    <div className="absolute right-0 z-20 mt-2 w-full rounded-lg border border-border bg-card p-2 text-card-foreground shadow-lg">
       {items.length ? (
         <ul className="space-y-1">
           {items.map((item) => (
@@ -18,16 +18,16 @@ export function SearchResults({ items, emptyText, onSelect }: SearchResultsProps
               <Link
                 href={item.href}
                 onClick={onSelect}
-                className="block rounded-md px-2 py-1.5 hover:bg-slate-100 dark:hover:bg-slate-800"
+                className="block rounded-md px-2 py-1.5 hover:bg-accent/70"
               >
                 <p className="text-sm font-medium">{item.title}</p>
-                <p className="line-clamp-1 text-xs text-slate-600 dark:text-slate-300">{item.description}</p>
+                <p className="line-clamp-1 text-xs text-muted-foreground">{item.description}</p>
               </Link>
             </li>
           ))}
         </ul>
       ) : (
-        <p className="px-2 py-1 text-sm text-slate-500 dark:text-slate-400">{emptyText}</p>
+        <p className="px-2 py-1 text-sm text-muted-foreground">{emptyText}</p>
       )}
     </div>
   );

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -6,7 +6,7 @@ export function Badge({ className, ...props }: BadgeProps) {
   return (
     <span
       className={cn(
-        "inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 text-xs font-semibold text-slate-700 dark:bg-slate-800 dark:text-slate-200",
+        "inline-flex items-center rounded-full bg-secondary px-2 py-0.5 text-xs font-semibold text-secondary-foreground",
         className,
       )}
       {...props}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -17,10 +17,9 @@ type ButtonAsChild = {
 };
 
 const variants: Record<Variant, string> = {
-  solid: "bg-slate-900 text-white hover:bg-slate-700 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-300",
-  outline:
-    "border border-slate-300 bg-transparent text-slate-900 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-100 dark:hover:bg-slate-800",
-  ghost: "bg-transparent text-slate-700 hover:bg-slate-100 dark:text-slate-100 dark:hover:bg-slate-800",
+  solid: "bg-primary text-primary-foreground hover:bg-primary/90",
+  outline: "border border-border bg-transparent text-foreground hover:bg-accent hover:text-accent-foreground",
+  ghost: "bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground",
 };
 
 export function Button(props: ButtonAsButton | ButtonAsChild) {
@@ -31,7 +30,7 @@ export function Button(props: ButtonAsButton | ButtonAsChild) {
 
     return React.cloneElement(children, {
       className: cn(
-        "inline-flex h-10 items-center rounded-md px-4 text-sm font-medium transition-colors",
+        "inline-flex h-10 items-center rounded-md px-4 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
         variants[variant],
         className,
         children.props.className,
@@ -44,7 +43,7 @@ export function Button(props: ButtonAsButton | ButtonAsChild) {
   return (
     <button
       className={cn(
-        "inline-flex h-10 items-center rounded-md px-4 text-sm font-medium transition-colors",
+        "inline-flex h-10 items-center rounded-md px-4 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
         variants[variant],
         className,
       )}

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -6,7 +6,7 @@ export function Card({ className, ...props }: CardProps) {
   return (
     <div
       className={cn(
-        "rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900",
+        "rounded-xl border border-border bg-card p-5 text-card-foreground shadow-sm",
         className,
       )}
       {...props}

--- a/src/components/ui/Collapsible.tsx
+++ b/src/components/ui/Collapsible.tsx
@@ -16,16 +16,16 @@ export function Collapsible({ title, children, defaultOpen = false, className }:
   const contentId = useId();
 
   return (
-    <section className={cn("rounded-lg border border-slate-200 p-2 dark:border-slate-800", className)}>
+    <section className={cn("rounded-lg border border-border bg-card p-2 text-card-foreground", className)}>
       <button
         type="button"
-        className="flex w-full items-center justify-between px-1 py-1 text-left text-sm font-semibold"
+        className="flex w-full items-center justify-between rounded-md px-1 py-1 text-left text-sm font-semibold hover:bg-accent/60"
         aria-expanded={open}
         aria-controls={contentId}
         onClick={() => setOpen((value) => !value)}
       >
         {title}
-        <span className="text-xs text-slate-500">{open ? "Ocultar" : "Mostrar"}</span>
+        <span className="text-xs text-muted-foreground">{open ? "Ocultar" : "Mostrar"}</span>
       </button>
       {open ? (
         <div id={contentId} className="pt-2">

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -8,7 +8,7 @@ export const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttribute
       <input
         ref={ref}
         className={cn(
-          "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm outline-none ring-offset-2 focus:border-slate-500 focus:ring-2 focus:ring-slate-300 dark:border-slate-700 dark:bg-slate-900 dark:focus:border-slate-500 dark:focus:ring-slate-700",
+          "w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground outline-none ring-offset-background placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring",
           className,
         )}
         {...props}

--- a/src/mdx-components.tsx
+++ b/src/mdx-components.tsx
@@ -8,7 +8,7 @@ export function Formula({ children }: SharedProps) {
   return (
     <div className="rounded-xl border border-indigo-200 bg-indigo-50/70 p-4 dark:border-indigo-800 dark:bg-indigo-950/40" aria-label="Fórmula destacada">
       <p className="text-xs font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">Fórmula</p>
-      <div className="mt-2 text-sm text-slate-800 dark:text-slate-100">{children}</div>
+      <div className="mt-2 text-sm text-foreground">{children}</div>
     </div>
   );
 }
@@ -17,7 +17,7 @@ export function Ejemplo({ children }: SharedProps) {
   return (
     <aside className="rounded-xl border border-emerald-200 bg-emerald-50/70 p-4 dark:border-emerald-800 dark:bg-emerald-950/40" aria-label="Ejemplo">
       <p className="text-xs font-semibold uppercase tracking-wide text-emerald-700 dark:text-emerald-300">Ejemplo</p>
-      <div className="mt-2 text-sm text-slate-800 dark:text-slate-100">{children}</div>
+      <div className="mt-2 text-sm text-foreground">{children}</div>
     </aside>
   );
 }
@@ -26,7 +26,7 @@ export function Nota({ children }: SharedProps) {
   return (
     <aside className="rounded-xl border border-amber-200 bg-amber-50/70 p-4 dark:border-amber-800 dark:bg-amber-950/40" aria-label="Nota importante">
       <p className="text-xs font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300">Nota</p>
-      <div className="mt-2 text-sm text-slate-800 dark:text-slate-100">{children}</div>
+      <div className="mt-2 text-sm text-foreground">{children}</div>
     </aside>
   );
 }


### PR DESCRIPTION
### Motivation
- Mejorar legibilidad y contraste en modo claro sin degradar el modo oscuro reemplazando clases de color hardcodeadas por tokens semánticos basados en variables CSS.
- Unificar primitives UI (botones, inputs, tarjetas, badges, collapsibles) para que los temas se resuelvan vía variables y mantener coherencia visual entre light/dark.

### Description
- Agregué y mapeé tokens semánticos en `src/app/globals.css` para light y `.dark`: `background`, `foreground`, `muted`, `muted-foreground`, `card`, `card-foreground`, `border`, `input`, `ring`, `accent`, `accent-foreground`, `primary`, `primary-foreground`, `secondary`, `secondary-foreground`.
- Migré componentes base a clases semánticas: `Button`, `Input`, `Card`, `Badge`, `Collapsible` (incluye focus/ring consistente con `ring-ring`).
- Ajusté navegación y layout visibles para usar tokens: `Sidebar`, `Header`, `MobileDrawer`, `SearchResults`, `PrevNext`, páginas (`/app/page`, unidad pages) y renderizadores de contenido (`renderTokens`, `InlineMath`, `BlockMath`, `FormulaCard`, `mdx-components`).
- Cambios menores de UX: item activo del sidebar usa `bg-accent + text-foreground + font-semibold`, items inactivos usan `text-muted-foreground` y `hover:text-foreground`; botones añaden `focus-visible:ring` helpers.

### Testing
- Ejecuté búsqueda para detectar hardcodes (`rg`): no quedan coincidencias de `text-slate-*`, `bg-slate-*`, `text-zinc-*`, `bg-zinc-*`, `text-white`, `text-black` en `src/` (éxito).
- `npm run lint` falló por falta de la dependencia de ESLint en el entorno (`Error: Cannot find package 'eslint'`).
- `npm run build` y `npm run dev` fallaron porque `next`/dependencias no están instaladas en el entorno (`next: not found`) y `npm install` está bloqueado por políticas del registry (`403 Forbidden` para algunas dependencias), por lo que no fue posible levantar la app aquí.
- Commit con los cambios aplicado y listo para revisión (21 archivos modificados; cambios de estilo/tokens únicamente).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69909667c184832d9e6e8600aafa26ee)