### PR TITLE
home: add Ingenium service label

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -57,7 +57,10 @@ export default function HomePage() {
     <main className="mx-auto w-full max-w-5xl space-y-10 px-4 py-12 sm:px-6 lg:px-8">
       <section className="space-y-6">
         <Badge>Unidad activa</Badge>
-        <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Consulta de Electrotecnia</h1>
+        <div className="space-y-1">
+          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Consulta de Electrotecnia</h1>
+          <p className="text-sm text-muted-foreground">Un servicio de Ingenium</p>
+        </div>
         <p className="max-w-3xl text-muted-foreground">
           Esta wiki está pensada para estudiantes que necesitan entender, repasar y practicar Electricidad de forma
           ordenada. Podés recorrerla en secuencia como curso breve o usarla como apunte rápido por tema.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -57,8 +57,9 @@ export default function HomePage() {
     <main className="mx-auto w-full max-w-5xl space-y-10 px-4 py-12 sm:px-6 lg:px-8">
       <section className="space-y-6">
         <Badge>Unidad activa</Badge>
-        <div className="space-y-1">
+        <div className="space-y-2">
           <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Consulta de Electrotecnia</h1>
+          <p className="text-base font-semibold tracking-[0.28em] text-amber-700/90 sm:text-lg">INGENIUM</p>
           <p className="text-sm text-muted-foreground">Un servicio de Ingenium</p>
         </div>
         <p className="max-w-3xl text-muted-foreground">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,12 +56,11 @@ export default function HomePage() {
   return (
     <main className="mx-auto w-full max-w-5xl space-y-10 px-4 py-12 sm:px-6 lg:px-8">
       <section className="space-y-6">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Esta web es un servicio de <span className="font-semibold tracking-[0.28em] text-amber-700/90">INGENIUM</span>
+        </p>
         <Badge>Unidad activa</Badge>
-        <div className="space-y-2">
-          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Consulta de Electrotecnia</h1>
-          <p className="text-base font-semibold tracking-[0.28em] text-amber-700/90 sm:text-lg">INGENIUM</p>
-          <p className="text-sm text-muted-foreground">Un servicio de Ingenium</p>
-        </div>
+        <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Consulta de Electrotecnia</h1>
         <p className="max-w-3xl text-muted-foreground">
           Esta wiki está pensada para estudiantes que necesitan entender, repasar y practicar Electricidad de forma
           ordenada. Podés recorrerla en secuencia como curso breve o usarla como apunte rápido por tema.


### PR DESCRIPTION
### Motivation
- Mostrar una leyenda discreta junto al título principal de la Home para indicar que el sitio es “Un servicio de Ingenium” manteniendo la estética actual.

### Description
- Añadido un subtítulo en `src/app/page.tsx` envolviendo el título en `<div className="space-y-1">` y agregando `<p className="text-sm text-muted-foreground">Un servicio de Ingenium</p>` para mantener tipografía y colores existentes.
- El cambio está limitado a la página raíz y no modifica otras rutas ni la estructura existente.

### Testing
- Ejecuté `npm run lint` y falló por falta del paquete `eslint` en el entorno local. 
- Ejecuté `npm ci` y falló con `403 Forbidden` al resolver la dependencia `katex` desde el registry. 
- Ejecuté `npm run dev`, el script `predev` generó el índice de búsqueda pero `next` no pudo iniciarse porque el binario no está disponible en el entorno.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991262f01e8832d8e6fad26241f5a71)