### PR TITLE
Agregar bloque interactivo de prefijos SI en la página de unidad Electricidad

### DIFF
--- a/src/app/unidad/electricidad/page.tsx
+++ b/src/app/unidad/electricidad/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { createPageMetadata } from "@/lib/seo";
 import { getPartFirstTopic, getSectionNodes } from "@/lib/nav";
 
+import { SIPrefixesCard } from "@/components/content/SIPrefixesCard";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 
@@ -42,14 +43,18 @@ export default function ElectricidadIndexPage() {
         </Card>
       </div>
 
-      <section className="rounded-xl border border-border p-5">
-        <h2 className="text-xl font-semibold">Glosario de unidades</h2>
-        <ul className="mt-3 flex flex-wrap gap-2">
-          {glossary.map((item) => (
-            <li key={item} className="rounded-md border border-border px-3 py-1 font-mono text-sm">{item}</li>
-          ))}
-        </ul>
-      </section>
+      <div className="grid gap-4 lg:grid-cols-2">
+        <section className="rounded-xl border border-border p-5">
+          <h2 className="text-xl font-semibold">Glosario de unidades</h2>
+          <ul className="mt-3 flex flex-wrap gap-2">
+            {glossary.map((item) => (
+              <li key={item} className="rounded-md border border-border px-3 py-1 font-mono text-sm">{item}</li>
+            ))}
+          </ul>
+        </section>
+
+        <SIPrefixesCard />
+      </div>
     </div>
   );
 }

--- a/src/components/content/SIPrefixesCard.tsx
+++ b/src/components/content/SIPrefixesCard.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+type SIPrefix = {
+  name: string;
+  symbol: string;
+  exponent: string;
+};
+
+const siPrefixes: SIPrefix[] = [
+  { name: "Yotta", symbol: "Y", exponent: "10^24" },
+  { name: "Zetta", symbol: "Z", exponent: "10^21" },
+  { name: "Exa", symbol: "E", exponent: "10^18" },
+  { name: "Peta", symbol: "P", exponent: "10^15" },
+  { name: "Tera", symbol: "T", exponent: "10^12" },
+  { name: "Giga", symbol: "G", exponent: "10^9" },
+  { name: "Mega", symbol: "M", exponent: "10^6" },
+  { name: "kilo", symbol: "k", exponent: "10^3" },
+  { name: "hecto", symbol: "h", exponent: "10^2" },
+  { name: "deca", symbol: "da", exponent: "10^1" },
+  { name: "deci", symbol: "d", exponent: "10^-1" },
+  { name: "centi", symbol: "c", exponent: "10^-2" },
+  { name: "mili", symbol: "m", exponent: "10^-3" },
+  { name: "micro", symbol: "µ", exponent: "10^-6" },
+  { name: "nano", symbol: "n", exponent: "10^-9" },
+  { name: "pico", symbol: "p", exponent: "10^-12" },
+  { name: "femto", symbol: "f", exponent: "10^-15" },
+  { name: "atto", symbol: "a", exponent: "10^-18" },
+  { name: "zepto", symbol: "z", exponent: "10^-21" },
+  { name: "yocto", symbol: "y", exponent: "10^-24" },
+];
+
+const chipBaseClassName =
+  "rounded-md border border-border px-3 py-1 font-mono text-sm text-foreground transition-colors hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background";
+
+export function SIPrefixesCard() {
+  const [selectedPrefix, setSelectedPrefix] = useState<SIPrefix>(siPrefixes[7]);
+
+  return (
+    <section className="rounded-xl border border-border p-5">
+      <h2 className="text-xl font-semibold">Múltiplos y submúltiplos (SI)</h2>
+
+      <ul className="mt-3 flex flex-wrap gap-2" aria-label="Prefijos SI comunes">
+        {siPrefixes.map((prefix) => {
+          const isSelected = selectedPrefix.symbol === prefix.symbol;
+
+          return (
+            <li key={prefix.symbol}>
+              <button
+                type="button"
+                className={cn(
+                  chipBaseClassName,
+                  isSelected && "border-primary bg-primary/10 text-foreground",
+                )}
+                onClick={() => setSelectedPrefix(prefix)}
+                aria-pressed={isSelected}
+              >
+                {prefix.name} ({prefix.symbol})
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      <p className="mt-4 text-sm text-muted-foreground" aria-live="polite">
+        {selectedPrefix.name} — {selectedPrefix.symbol} — {selectedPrefix.exponent}
+      </p>
+    </section>
+  );
+}


### PR DESCRIPTION
### Motivation
- Añadir al índice de la unidad un bloque visual con los múltiplos y submúltiplos del SI para referencia rápida con el mismo look&feel del glosario existente.
- Mantener la implementación data-driven y accesible para facilitar futuras ediciones y navegación por teclado.
- Reutilizar patrones y estilos ya presentes en la página para evitar duplicar lógica o agregar dependencias.

### Description
- Se añadió un componente cliente `SIPrefixesCard` que contiene un array tipado `siPrefixes` con los 20 prefijos SI (Yotta…yocto) y renderiza chips interactivos; la selección muestra `Nombre — Símbolo — Notación científica` debajo.  
- El componente reutiliza las clases y patrones visuales del glosario (card, border, padding y chips con foco visible) y usa `aria-pressed` y `aria-live="polite"` para accesibilidad.  
- El bloque quedó ubicado junto al bloque existente “Glosario de unidades” dentro de un contenedor `grid` que presenta 2 columnas en `lg` (la tarjeta de glosario + `SIPrefixesCard`).  
- Archivos modificados: `src/app/unidad/electricidad/page.tsx` y `src/components/content/SIPrefixesCard.tsx`.

### Testing
- Ejecuté `npm run lint` y falló en este entorno por dependencias ausentes (`Cannot find package 'eslint'`).  
- Ejecuté `npm install` y falló por restricciones del registry en este entorno (`403 Forbidden` para `katex`), por lo que no se pudieron instalar dependencias.  
- Ejecuté `npm run build` parcialmente; el `prebuild` generó `src/content/search-index.json` pero el `next build` no pudo ejecutarse porque `next` no está instalado (`next: not found`).  
- Intento de captura visual con Playwright falló porque no había servidor disponible (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69914457c5a0832da6648019f0ac0711)