### PR TITLE
Improve KaTeX math presentation styling for book-like display

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -61,3 +61,33 @@ body {
   color: var(--foreground);
   font-family: var(--font-sans), system-ui, sans-serif;
 }
+
+.math-inline {
+  display: inline-flex;
+  align-items: baseline;
+  line-height: 1.5;
+}
+
+.math-display {
+  -webkit-overflow-scrolling: touch;
+}
+
+.math-display .katex-display {
+  margin: 0;
+  text-align: center;
+}
+
+.math-display .katex {
+  font-size: 1.1rem;
+  line-height: 1.45;
+}
+
+@media (max-width: 640px) {
+  .math-display {
+    padding-inline: 0.75rem;
+  }
+
+  .math-display .katex {
+    font-size: 1rem;
+  }
+}

--- a/src/components/content/BlockMath.tsx
+++ b/src/components/content/BlockMath.tsx
@@ -21,14 +21,14 @@ export function BlockMath({ latex }: BlockMathProps) {
 
   if (!html) {
     return (
-      <div className="my-3 overflow-x-auto rounded-md bg-secondary px-3 py-2 font-mono text-sm">
+      <div className="math-display my-5 overflow-x-auto rounded-lg border border-border/70 bg-secondary/80 px-4 py-3 font-mono text-sm leading-relaxed">
         {latex}
       </div>
     );
   }
 
   return (
-    <div className="my-3 overflow-x-auto rounded-md bg-secondary px-3 py-2">
+    <div className="math-display my-5 overflow-x-auto rounded-lg border border-border/70 bg-secondary/60 px-4 py-3">
       <div className="min-w-max" dangerouslySetInnerHTML={{ __html: html }} />
     </div>
   );

--- a/src/components/content/InlineMath.tsx
+++ b/src/components/content/InlineMath.tsx
@@ -23,5 +23,5 @@ export function InlineMath({ latex }: InlineMathProps) {
     return <code className="rounded bg-secondary px-1 py-0.5 text-xs">{latex}</code>;
   }
 
-  return <span className="katex-inline" dangerouslySetInnerHTML={{ __html: html }} />;
+  return <span className="math-inline" dangerouslySetInnerHTML={{ __html: html }} />;
 }

--- a/src/components/content/cards/EjemploCard.tsx
+++ b/src/components/content/cards/EjemploCard.tsx
@@ -9,7 +9,7 @@ export function EjemploCard({ block }: EjemploCardProps) {
   return (
     <section className="rounded-xl border border-violet-200 bg-violet-50/70 p-5 shadow-sm dark:border-violet-900 dark:bg-violet-950/30">
       <h2 className="text-lg font-semibold text-violet-900 dark:text-violet-100">{block.title}</h2>
-      <div className="mt-2 space-y-2 [&_.katex-inline]:align-middle [&_.katex-display]:my-3">
+      <div className="mt-2 space-y-2 [&_.math-inline]:align-middle [&_.katex-inline]:align-middle [&_.katex-display]:my-3">
         {renderContentNodes(block.nodes ?? [], block.body, true, {
           renderParagraphLines: true,
           linesContainerClassName: "space-y-2",


### PR DESCRIPTION
### Motivation
- The Coulomb page uses math but formulas looked like plain text; the goal was to make display and inline math look “como en los libros” with correct math typography and spacing.
- An audit showed the project already tokenizes math and uses KaTeX at render time (not MathJax), and KaTeX CSS was already imported globally.

### Description
- Use KaTeX rendering path and add a semantic inline wrapper by changing `InlineMath` to output a `math-inline` span to control vertical alignment and line-height (`src/components/content/InlineMath.tsx`).
- Improve the display-math container with tuned spacing, padding, subtle background and border, and robust horizontal overflow handling, while still rendering KaTeX HTML via `dangerouslySetInnerHTML` (`src/components/content/BlockMath.tsx`).
- Add global CSS rules for `.math-inline` and `.math-display` to center display math, increase math font-size/line-height, and adjust responsive behavior on mobile (`src/app/globals.css`).
- Align example card selectors to the new wrapper so inline/display math keeps expected alignment (`src/components/content/cards/EjemploCard.tsx`).

### Testing
- Attempted `npm install` failed due to registry/network policy (`403 Forbidden`), so dependencies were not installed and runtime verification could not be completed; this blocked further automated checks.
- `npm run lint` was executed but failed due to missing `eslint` (dependency not installed) and therefore did not complete successfully.
- `npm run test:parse-smoke` was executed but failed due to missing `typescript` (dependency not installed) and therefore did not complete successfully.
- `npm run build` was attempted and failed because the `next` binary is not available without installed dependencies, so build verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991466362ac832d946b2dab0ec4ed68)