### PR TITLE
Render SI prefix exponents with KaTeX inline math

### DIFF
--- a/src/components/content/SIPrefixesCard.tsx
+++ b/src/components/content/SIPrefixesCard.tsx
@@ -2,35 +2,36 @@
 
 import { useState } from "react";
 
+import { InlineMath } from "@/components/content/InlineMath";
 import { cn } from "@/lib/utils";
 
 type SIPrefix = {
   name: string;
   symbol: string;
-  exponent: string;
+  exponentLatex: string;
 };
 
 const siPrefixes: SIPrefix[] = [
-  { name: "Yotta", symbol: "Y", exponent: "10^24" },
-  { name: "Zetta", symbol: "Z", exponent: "10^21" },
-  { name: "Exa", symbol: "E", exponent: "10^18" },
-  { name: "Peta", symbol: "P", exponent: "10^15" },
-  { name: "Tera", symbol: "T", exponent: "10^12" },
-  { name: "Giga", symbol: "G", exponent: "10^9" },
-  { name: "Mega", symbol: "M", exponent: "10^6" },
-  { name: "kilo", symbol: "k", exponent: "10^3" },
-  { name: "hecto", symbol: "h", exponent: "10^2" },
-  { name: "deca", symbol: "da", exponent: "10^1" },
-  { name: "deci", symbol: "d", exponent: "10^-1" },
-  { name: "centi", symbol: "c", exponent: "10^-2" },
-  { name: "mili", symbol: "m", exponent: "10^-3" },
-  { name: "micro", symbol: "µ", exponent: "10^-6" },
-  { name: "nano", symbol: "n", exponent: "10^-9" },
-  { name: "pico", symbol: "p", exponent: "10^-12" },
-  { name: "femto", symbol: "f", exponent: "10^-15" },
-  { name: "atto", symbol: "a", exponent: "10^-18" },
-  { name: "zepto", symbol: "z", exponent: "10^-21" },
-  { name: "yocto", symbol: "y", exponent: "10^-24" },
+  { name: "Yotta", symbol: "Y", exponentLatex: "10^{24}" },
+  { name: "Zetta", symbol: "Z", exponentLatex: "10^{21}" },
+  { name: "Exa", symbol: "E", exponentLatex: "10^{18}" },
+  { name: "Peta", symbol: "P", exponentLatex: "10^{15}" },
+  { name: "Tera", symbol: "T", exponentLatex: "10^{12}" },
+  { name: "Giga", symbol: "G", exponentLatex: "10^{9}" },
+  { name: "Mega", symbol: "M", exponentLatex: "10^{6}" },
+  { name: "kilo", symbol: "k", exponentLatex: "10^{3}" },
+  { name: "hecto", symbol: "h", exponentLatex: "10^{2}" },
+  { name: "deca", symbol: "da", exponentLatex: "10^{1}" },
+  { name: "deci", symbol: "d", exponentLatex: "10^{-1}" },
+  { name: "centi", symbol: "c", exponentLatex: "10^{-2}" },
+  { name: "mili", symbol: "m", exponentLatex: "10^{-3}" },
+  { name: "micro", symbol: "µ", exponentLatex: "10^{-6}" },
+  { name: "nano", symbol: "n", exponentLatex: "10^{-9}" },
+  { name: "pico", symbol: "p", exponentLatex: "10^{-12}" },
+  { name: "femto", symbol: "f", exponentLatex: "10^{-15}" },
+  { name: "atto", symbol: "a", exponentLatex: "10^{-18}" },
+  { name: "zepto", symbol: "z", exponentLatex: "10^{-21}" },
+  { name: "yocto", symbol: "y", exponentLatex: "10^{-24}" },
 ];
 
 const chipBaseClassName =
@@ -66,7 +67,7 @@ export function SIPrefixesCard() {
       </ul>
 
       <p className="mt-4 text-sm text-muted-foreground" aria-live="polite">
-        {selectedPrefix.name} — {selectedPrefix.symbol} — {selectedPrefix.exponent}
+        {selectedPrefix.name} — {selectedPrefix.symbol} — <InlineMath latex={selectedPrefix.exponentLatex} />
       </p>
     </section>
   );


### PR DESCRIPTION
### Motivation
- Make the scientific notation in the "Múltiplos y submúltiplos" UI render as math (KaTeX) with properly braced exponents (`10^{n}`) instead of plain text so exponents appear typeset and positioned correctly.

### Description
- Updated `src/components/content/SIPrefixesCard.tsx` to store exponents in LaTeX form and render them with the existing `InlineMath` component; renamed `exponent` -> `exponentLatex` and replaced entries like `"10^24"` with `"10^{24}"`.
- Replaced the plain text rendering of the selected prefix exponent with `<InlineMath latex={selectedPrefix.exponentLatex} />` so the UI shows KaTeX-styled math.
- Change is limited to the SI prefixes component and does not modify MDX content or code blocks.
- Examples (before → after): ` { name: "Yotta", symbol: "Y", exponent: "10^24" }` → ` { name: "Yotta", symbol: "Y", exponentLatex: "10^{24}" }`; `{selectedPrefix.exponent}` → `<InlineMath latex={selectedPrefix.exponentLatex} />`.

### Testing
- Ran `npm run lint` and it failed in this environment due to a missing `eslint` package.
- Ran `npm run test:parse-smoke` and it failed due to a missing `typescript` package.
- Ran `npm run build` and it failed because `next` is not available and dependency installation is blocked in this environment; no automated test completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69914bf7fd44832db6f01f287ee9d202)