### PR TITLE
Rediseña la sección "Ruta sugerida" en la home

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -74,13 +74,49 @@ export default function HomePage() {
               <Link href="/unidad/electricidad">Ir a Unidad: Electricidad</Link>
             </Button>
           </div>
-          <aside className="surface-panel flex flex-col justify-between gap-4 rounded-2xl p-5">
+          <aside className="surface-panel relative rounded-2xl p-5">
             <p className="text-xs font-semibold uppercase tracking-[0.15em] text-muted-foreground">Ruta sugerida</p>
-            <ol className="space-y-3 text-sm text-muted-foreground">
-              <li className="rounded-xl border border-border/70 bg-card/70 p-3">1. Cargas, campos y potencial</li>
-              <li className="rounded-xl border border-border/70 bg-card/70 p-3">2. Corriente, tensión y resistencia</li>
-              <li className="rounded-xl border border-border/70 bg-card/70 p-3">3. Leyes de Ohm, Joule y Kirchhoff</li>
-            </ol>
+
+            <div className="relative mt-4 h-[500px] rounded-2xl border border-border/50 bg-gradient-to-b from-background/60 via-background/25 to-background/70 p-4">
+              <div
+                aria-hidden="true"
+                className="absolute left-8 top-[72px] h-[344px] w-[calc(100%-4rem)] rounded-[30px] border border-[var(--highlight)]/35"
+              />
+              <div aria-hidden="true" className="absolute left-8 top-[72px] h-[344px] border-l-2 border-dashed border-[var(--highlight)]/40" />
+
+              <span
+                aria-hidden="true"
+                className="absolute left-7 top-[72px] h-2.5 w-2.5 rounded-full bg-[var(--highlight)] shadow-[0_0_20px_rgba(255,168,92,0.95)]"
+              />
+              <span
+                aria-hidden="true"
+                className="absolute left-7 top-[236px] h-2.5 w-2.5 rounded-full bg-[var(--highlight)] shadow-[0_0_20px_rgba(255,168,92,0.95)]"
+              />
+              <span
+                aria-hidden="true"
+                className="absolute right-7 top-[236px] h-2.5 w-2.5 rounded-full bg-[var(--highlight)] shadow-[0_0_20px_rgba(255,168,92,0.95)]"
+              />
+              <span
+                aria-hidden="true"
+                className="absolute left-7 top-[396px] h-2.5 w-2.5 rounded-full bg-[var(--highlight)] shadow-[0_0_20px_rgba(255,168,92,0.95)]"
+              />
+              <span
+                aria-hidden="true"
+                className="absolute right-7 top-[396px] h-2.5 w-2.5 rounded-full bg-[var(--highlight)] shadow-[0_0_20px_rgba(255,168,92,0.95)]"
+              />
+
+              <ol className="relative z-10 space-y-12 pt-4 text-base text-foreground/90">
+                <li className="rounded-2xl border border-[var(--highlight)]/35 bg-card/65 px-5 py-4 shadow-[inset_0_0_0_1px_rgba(255,168,92,0.08)]">
+                  1. Cargas, campos y potencial
+                </li>
+                <li className="rounded-2xl border border-[var(--highlight)]/35 bg-card/65 px-5 py-4 shadow-[inset_0_0_0_1px_rgba(255,168,92,0.08)]">
+                  2. Corriente, tensión y resistencia
+                </li>
+                <li className="rounded-2xl border border-[var(--highlight)]/35 bg-card/65 px-5 py-4 shadow-[inset_0_0_0_1px_rgba(255,168,92,0.08)]">
+                  3. Leyes de Ohm, Joule y Kirchhoff
+                </li>
+              </ol>
+            </div>
           </aside>
         </div>
       </section>


### PR DESCRIPTION
### Motivation
- Reemplazar la lista simple de la sección “Ruta sugerida” por un diseño visual más guiado (contorno, trazo tipo circuito y nodos) para parecerse al mock provisto y mejorar la jerarquía de estudio.

### Description
- Sustituí el bloque aside existente por un contenedor interno con gradiente y marco en `src/app/page.tsx` para la sección de la derecha de la home. 
- Añadí trazos decorativos absolutos (línea punteada y nodos con glow) y tarjetas de pasos con bordes y sombra para los tres pasos, manteniendo el texto original. 
- El cambio es puramente visual y afecta únicamente a `src/app/page.tsx`.

### Testing
- Ejecuté `npm run lint`: fallo por dependencias del entorno (`eslint/config` no encontrado). 
- Ejecuté `npm run build`: el paso de prebuild `scripts/generate-search-index.mjs` generó `src/content/search-index.json`, pero `next build` falló porque `next` no está disponible en el entorno. 
- No se pudieron completar más pruebas automatizadas debido a problemas de dependencias/entorno.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699604360d50832da1dba2cb6e024ce0)